### PR TITLE
Commissioning Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ In [dotnet/PITreaderTool](dotnet/PITreaderTool) you can find an example applicat
 - monitoring a device for change
 - updating the firmware of a device
 
+## Commissioning and Setup Tool
+
+In [dotnet/PITreaderCommissioningTool](dotnet/PITreaderCommissioningTool) you can find a tool to automate the setup and customization of PITreader devices from unboxing to a fully operational and configured state.
 
 ## Support
 

--- a/dotnet/PITreaderClient.sln
+++ b/dotnet/PITreaderClient.sln
@@ -7,7 +7,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PITreaderClient", "PITreade
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PITreaderTool", "PITreaderTool\PITreaderTool.csproj", "{5A4A9EBF-5BA5-44AE-A50D-167A15A7B2F8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PITreaderClient.Tests", "PITreaderClient.Tests\PITreaderClient.Tests.csproj", "{CDBAA022-5314-4B77-AD39-5FF9EC0F5D84}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PITreaderClient.Tests", "PITreaderClient.Tests\PITreaderClient.Tests.csproj", "{CDBAA022-5314-4B77-AD39-5FF9EC0F5D84}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox", "Sandbox\Sandbox.csproj", "{8F53CD38-6A31-49E4-A2AC-DFB7926A8B3D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PITreaderNetwork", "PITreaderNetwork\PITreaderNetwork.csproj", "{A047F63D-ED9F-4428-92BF-DAC4528EF07B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PITreaderCommissioningTool", "PITreaderCommissioningTool\PITreaderCommissioningTool.csproj", "{36DB00D9-3CED-435B-AD78-4FD46A571B95}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PITreaderConfiguration", "PITreaderConfiguration\PITreaderConfiguration.csproj", "{12F059BD-3164-4582-81E0-98E33D2DE4D0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PITreaderConfiguration.Tests", "PITreaderConfiguration.Tests\PITreaderConfiguration.Tests.csproj", "{3940FF67-395D-4583-97B5-BF396E843213}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +37,26 @@ Global
 		{CDBAA022-5314-4B77-AD39-5FF9EC0F5D84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CDBAA022-5314-4B77-AD39-5FF9EC0F5D84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDBAA022-5314-4B77-AD39-5FF9EC0F5D84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F53CD38-6A31-49E4-A2AC-DFB7926A8B3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F53CD38-6A31-49E4-A2AC-DFB7926A8B3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F53CD38-6A31-49E4-A2AC-DFB7926A8B3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F53CD38-6A31-49E4-A2AC-DFB7926A8B3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A047F63D-ED9F-4428-92BF-DAC4528EF07B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A047F63D-ED9F-4428-92BF-DAC4528EF07B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A047F63D-ED9F-4428-92BF-DAC4528EF07B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A047F63D-ED9F-4428-92BF-DAC4528EF07B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36DB00D9-3CED-435B-AD78-4FD46A571B95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36DB00D9-3CED-435B-AD78-4FD46A571B95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36DB00D9-3CED-435B-AD78-4FD46A571B95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36DB00D9-3CED-435B-AD78-4FD46A571B95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12F059BD-3164-4582-81E0-98E33D2DE4D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12F059BD-3164-4582-81E0-98E33D2DE4D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12F059BD-3164-4582-81E0-98E33D2DE4D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12F059BD-3164-4582-81E0-98E33D2DE4D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3940FF67-395D-4583-97B5-BF396E843213}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3940FF67-395D-4583-97B5-BF396E843213}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3940FF67-395D-4583-97B5-BF396E843213}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3940FF67-395D-4583-97B5-BF396E843213}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/dotnet/PITreaderClient/ApiEndpoints.cs
+++ b/dotnet/PITreaderClient/ApiEndpoints.cs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+using System.IO;
 using System.Threading.Tasks;
 using Pilz.PITreader.Client.Model;
 
@@ -46,6 +47,16 @@ namespace Pilz.PITreader.Client
         /// Blocklist endpoint.
         /// </summary>
         public const string ConfigBlocklist = "/api/config/blocklist";
+
+        /// <summary>
+        /// Regenerate certificate endpoint.
+        /// </summary>
+        public const string FilesCertificate = "/api/files/certificate";
+
+        /// <summary>
+        /// Regenerate certificate endpoint.
+        /// </summary>
+        public const string ConfigCertificateRegenerate = "/api/config/certificate/regenerate";
 
         /// <summary>
         /// Coding endpoint.
@@ -138,6 +149,16 @@ namespace Pilz.PITreader.Client
         public const string FirmwareUpdate = "/api/firmware/update";
 
         /// <summary>
+        /// OPC UA server certificate endpoint.
+        /// </summary>
+        public const string FilesOpcuaServer = "/api/files/opcua/server";
+
+        /// <summary>
+        /// Configuration backup endpoint.
+        /// </summary>
+        public const string FilesBackup = "/api/files/backup";
+
+        /// <summary>
         /// Read general device information (e.g. device name, order number, serial number, firmware version, hardware version, software version)
         /// </summary>
         /// <param name="client">PITreader client instance.</param>
@@ -207,7 +228,7 @@ namespace Pilz.PITreader.Client
         /// <returns></returns>
         public static Task<ApiResponse<GenericResponse>> SetOemCoding(this PITreaderClient client, OemCodingRequest coding)
         {
-            return client.PostAsync<GenericResponse, OemCodingRequest>(ConfigCoding, coding);
+            return client.PostAsync<GenericResponse, OemCodingRequest>(ConfigCodingOem, coding);
         }
 
         /// <summary>
@@ -348,6 +369,50 @@ namespace Pilz.PITreader.Client
         public static Task<ApiResponse<GenericResponse>> UpdatePermissionList(this PITreaderClient client, CrudAction action, PermissionListEntry entry)
         {
             return client.PostAsync<GenericResponse, PermissionListCrudRequest>(ConfigBlocklist, new PermissionListCrudRequest { Id = entry.Id, Action = action, Data = entry });
+        }
+
+        /// <summary>
+        /// Uploads a TLS certificate to the PITreader device.
+        /// </summary>
+        /// <param name="client">PITreader client instance.</param>
+        /// <param name="certificate">Stream with certificate data.</param>
+        /// <returns></returns>
+        public static Task<ApiResponse<GenericResponse>> UploadCertificate(this PITreaderClient client, Stream certificate)
+        {
+            return client.PostFileAsync<GenericResponse>(FilesCertificate, certificate, "cert.pem", "certFile", null, System.TimeSpan.FromSeconds(30));
+        }
+
+        /// <summary>
+        /// Request to renew certificate on PITreader device.
+        /// </summary>
+        /// <param name="client">PITreader client instance.</param>
+        /// <param name="scope">Scope of certificate renew request</param>
+        /// <returns></returns>
+        public static Task<ApiResponse<GenericResponse>> RegenerateCertificate(this PITreaderClient client, CertificateRegenerateScope scope)
+        {
+            return client.PostAsync<GenericResponse, CertificateRegenerateRequest>(ConfigCertificateRegenerate, new CertificateRegenerateRequest { Scope = scope });
+        }
+
+        /// <summary>
+        /// Downloads the current OPC UA Server certificate to provided io stream.
+        /// </summary>
+        /// <param name="client">PITreader client instance.</param>
+        /// <param name="stream">IO stream to receive the certificate data.</param>
+        /// <returns></returns>
+        public static Task<ApiResponse<Stream>> GetOpcUaServerCertificate(this PITreaderClient client, Stream stream)
+        {
+            return client.GetFileAsync(FilesOpcuaServer, stream);
+        }
+
+        /// <summary>
+        /// Downloads the current configuration backup to provided io stream.
+        /// </summary>
+        /// <param name="client">PITreader client instance.</param>
+        /// <param name="stream">IO stream to receive the configuration backup.</param>
+        /// <returns></returns>
+        public static Task<ApiResponse<Stream>> GetConfigurationBackup(this PITreaderClient client, Stream stream)
+        {
+            return client.GetFileAsync(FilesBackup, stream);
         }
     }
 }

--- a/dotnet/PITreaderClient/FirmwareVersion.cs
+++ b/dotnet/PITreaderClient/FirmwareVersion.cs
@@ -242,6 +242,7 @@ namespace Pilz.PITreader.Client
             return a.CompareTo(b) != 0;
         }
 
+        /// <inheritdoc/>
         public static bool operator >(FirmwareVersion a, FirmwareVersion b)
         {
             if (a is null && b is null) return false;

--- a/dotnet/PITreaderClient/Model/CertificateRegenerateRequest.cs
+++ b/dotnet/PITreaderClient/Model/CertificateRegenerateRequest.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.Text.Json.Serialization;
+
+namespace Pilz.PITreader.Client.Model
+{
+    /// <summary>
+    /// Request to renew TLS certificate (and key)
+    /// </summary>
+    public class CertificateRegenerateRequest
+    {
+        /// <summary>
+        /// Scope of renew operation
+        /// </summary>
+        [JsonPropertyName("scope")]
+        public CertificateRegenerateScope Scope { get; set; }
+    }
+}

--- a/dotnet/PITreaderClient/Model/CertificateRegenerateScope.cs
+++ b/dotnet/PITreaderClient/Model/CertificateRegenerateScope.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Client.Model
+{
+    /// <summary>
+    /// Scope of certificate renew request
+    /// </summary>
+    public enum CertificateRegenerateScope
+    {
+        /// <summary>
+        /// Only renew certificate (keeps the same key) 
+        /// </summary>
+        CertOnly,
+
+        /// <summary>
+        /// Renew certificate and key
+        /// </summary>
+        All
+    }
+}

--- a/dotnet/PITreaderClient/PITreaderClient.csproj
+++ b/dotnet/PITreaderClient/PITreaderClient.csproj
@@ -16,7 +16,7 @@
     <PackageTags>PITreader Pilz rest json</PackageTags>
     <PackageIcon></PackageIcon>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>Initial version for PITreader FW 1.5.x</PackageReleaseNotes>
+    <PackageReleaseNotes>Initial version for PITreader FW 1.5</PackageReleaseNotes>
     <PackageId>Pilz.PITreader.Client</PackageId>
     <AssemblyName>Pilz.PITreader.Client</AssemblyName>
     <SignAssembly>false</SignAssembly>

--- a/dotnet/PITreaderClient/PITreaderClient.xml
+++ b/dotnet/PITreaderClient/PITreaderClient.xml
@@ -61,6 +61,16 @@
             Blocklist endpoint.
             </summary>
         </member>
+        <member name="F:Pilz.PITreader.Client.ApiEndpoints.FilesCertificate">
+            <summary>
+            Regenerate certificate endpoint.
+            </summary>
+        </member>
+        <member name="F:Pilz.PITreader.Client.ApiEndpoints.ConfigCertificateRegenerate">
+            <summary>
+            Regenerate certificate endpoint.
+            </summary>
+        </member>
         <member name="F:Pilz.PITreader.Client.ApiEndpoints.ConfigCoding">
             <summary>
             Coding endpoint.
@@ -149,6 +159,16 @@
         <member name="F:Pilz.PITreader.Client.ApiEndpoints.FirmwareUpdate">
             <summary>
             Firmware update endpoint.
+            </summary>
+        </member>
+        <member name="F:Pilz.PITreader.Client.ApiEndpoints.FilesOpcuaServer">
+            <summary>
+            OPC UA server certificate endpoint.
+            </summary>
+        </member>
+        <member name="F:Pilz.PITreader.Client.ApiEndpoints.FilesBackup">
+            <summary>
+            Configuration backup endpoint.
             </summary>
         </member>
         <member name="M:Pilz.PITreader.Client.ApiEndpoints.GetDeviceStatus(Pilz.PITreader.Client.PITreaderClient)">
@@ -302,6 +322,38 @@
             <param name="client">PITreader client instance.</param>
             <param name="action">Action to be performed.</param>
             <param name="entry">Data of the permission list entry.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Pilz.PITreader.Client.ApiEndpoints.UploadCertificate(Pilz.PITreader.Client.PITreaderClient,System.IO.Stream)">
+            <summary>
+            Uploads a TLS certificate to the PITreader device.
+            </summary>
+            <param name="client">PITreader client instance.</param>
+            <param name="certificate">Stream with certificate data.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Pilz.PITreader.Client.ApiEndpoints.RegenerateCertificate(Pilz.PITreader.Client.PITreaderClient,Pilz.PITreader.Client.Model.CertificateRegenerateScope)">
+            <summary>
+            Request to renew certificate on PITreader device.
+            </summary>
+            <param name="client">PITreader client instance.</param>
+            <param name="scope">Scope of certificate renew request</param>
+            <returns></returns>
+        </member>
+        <member name="M:Pilz.PITreader.Client.ApiEndpoints.GetOpcUaServerCertificate(Pilz.PITreader.Client.PITreaderClient,System.IO.Stream)">
+            <summary>
+            Downloads the current OPC UA Server certificate to provided io stream.
+            </summary>
+            <param name="client">PITreader client instance.</param>
+            <param name="stream">IO stream to receive the certificate data.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Pilz.PITreader.Client.ApiEndpoints.GetConfigurationBackup(Pilz.PITreader.Client.PITreaderClient,System.IO.Stream)">
+            <summary>
+            Downloads the current configuration backup to provided io stream.
+            </summary>
+            <param name="client">PITreader client instance.</param>
+            <param name="stream">IO stream to receive the configuration backup.</param>
             <returns></returns>
         </member>
         <member name="T:Pilz.PITreader.Client.ApiUtilities">
@@ -532,6 +584,9 @@
             <inheritdoc/>
         </member>
         <member name="M:Pilz.PITreader.Client.FirmwareVersion.op_Inequality(Pilz.PITreader.Client.FirmwareVersion,Pilz.PITreader.Client.FirmwareVersion)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Pilz.PITreader.Client.FirmwareVersion.op_GreaterThan(Pilz.PITreader.Client.FirmwareVersion,Pilz.PITreader.Client.FirmwareVersion)">
             <inheritdoc/>
         </member>
         <member name="M:Pilz.PITreader.Client.FirmwareVersion.op_LessThan(Pilz.PITreader.Client.FirmwareVersion,Pilz.PITreader.Client.FirmwareVersion)">
@@ -797,6 +852,31 @@
         <member name="P:Pilz.PITreader.Client.Model.BlocklistResponse.Items">
             <summary>
             List of blocklist entries stored on the device.
+            </summary>
+        </member>
+        <member name="T:Pilz.PITreader.Client.Model.CertificateRegenerateRequest">
+            <summary>
+            Request to renew TLS certificate (and key)
+            </summary>
+        </member>
+        <member name="P:Pilz.PITreader.Client.Model.CertificateRegenerateRequest.Scope">
+            <summary>
+            Scope of renew operation
+            </summary>
+        </member>
+        <member name="T:Pilz.PITreader.Client.Model.CertificateRegenerateScope">
+            <summary>
+            Scope of certificate renew request
+            </summary>
+        </member>
+        <member name="F:Pilz.PITreader.Client.Model.CertificateRegenerateScope.CertOnly">
+            <summary>
+            Only renew certificate (keeps the same key) 
+            </summary>
+        </member>
+        <member name="F:Pilz.PITreader.Client.Model.CertificateRegenerateScope.All">
+            <summary>
+            Renew certificate and key
             </summary>
         </member>
         <member name="T:Pilz.PITreader.Client.Model.CodingResponse">
@@ -2415,6 +2495,16 @@
             Default port number for HTTPS connections to PITreader devices.
             </summary>
         </member>
+        <member name="F:Pilz.PITreader.Client.PITreaderClient.client">
+            <summary>
+            Base client instance
+            </summary>
+        </member>
+        <member name="F:Pilz.PITreader.Client.PITreaderClient.handler">
+            <summary>
+            HTTP handler
+            </summary>
+        </member>
         <member name="M:Pilz.PITreader.Client.PITreaderClient.#ctor(System.String,System.UInt16,Pilz.PITreader.Client.CertificateValidationDelegate)">
             <summary>
             Create a new client instance.
@@ -2444,6 +2534,15 @@
             <param name="url">Endpoint</param>
             <returns></returns>
         </member>
+        <member name="M:Pilz.PITreader.Client.PITreaderClient.GetFileAsync(System.String,System.IO.Stream,System.Nullable{System.TimeSpan})">
+            <summary>
+            Executes an HTTP GET request to the given endpoint.
+            </summary>
+            <param name="url">Endpoint</param>
+            <param name="destinationStream">Stream to receive download data.</param>
+            <param name="timeout">Request timeout</param>
+            <returns></returns>
+        </member>
         <member name="M:Pilz.PITreader.Client.PITreaderClient.PostAsync``2(System.String,``1)">
             <summary>
             Executes an HTTP POST request to the given endpoint.
@@ -2462,7 +2561,7 @@
             <param name="url">Endpoint</param>
             <returns></returns>
         </member>
-        <member name="M:Pilz.PITreader.Client.PITreaderClient.PostFileAsync``1(System.String,System.IO.Stream,System.String,System.String,System.TimeSpan)">
+        <member name="M:Pilz.PITreader.Client.PITreaderClient.PostFileAsync``1(System.String,System.IO.Stream,System.String,System.String,System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.TimeSpan)">
             <summary>
             Executes an HTTP POST request to the given endpoint uploading a file.
             </summary>
@@ -2471,7 +2570,35 @@
             <param name="file">File contents</param>
             <param name="fileName">File name</param>
             <param name="fieldName">Field name</param>
+            <param name="additionalFields">Additional form fields/parameters</param>
             <param name="timeout">Request timeout</param>
+            <returns></returns>
+        </member>
+        <member name="M:Pilz.PITreader.Client.PITreaderClient.ExecuteRequest``1(System.Net.Http.HttpClient,System.Net.Http.HttpRequestMessage)">
+            <summary>
+            Executes an HTTP request with given HTTP client.
+            </summary>
+            <typeparam name="T">Type of the response object</typeparam>
+            <param name="client">The HTTP client</param>
+            <param name="message">The HTTP request message</param>
+            <returns>An ApiResponse</returns>
+        </member>
+        <member name="M:Pilz.PITreader.Client.PITreaderClient.ExecuteDownloadRequest(System.Net.Http.HttpClient,System.Net.Http.HttpRequestMessage,System.IO.Stream)">
+            <summary>
+            Executes an HTTP request with given HTTP client.
+            </summary>
+            <param name="client">The HTTP client</param>
+            <param name="message">The HTTP request message</param>
+            <param name="stream">Stream to receive file data</param>
+            <returns>An ApiResponse</returns>
+        </member>
+        <member name="M:Pilz.PITreader.Client.PITreaderClient.CreateClient(System.String,System.UInt16,System.Boolean)">
+            <summary>
+            Creates a new <see cref="T:System.Net.Http.HttpClient"/> instance.
+            </summary>
+            <param name="hostnameOrIp">Hostname or IP address of device.</param>
+            <param name="portNumber">HTTPS port number of device.</param>
+            <param name="disposeHandler">true if the inner handler should be disposed of by Dispose(), false if you intend to reuse the inner handler.</param>
             <returns></returns>
         </member>
         <member name="M:Pilz.PITreader.Client.PITreaderClient.Dispose(System.Boolean)">
@@ -2667,6 +2794,22 @@
             <summary>
             API response data
             </summary>
+        </member>
+        <member name="T:Pilz.PITreader.Client.Serialization.JsonCertificateRegenerateScopeConverter">
+            <summary>
+            Converts between <see cref="T:Pilz.PITreader.Client.Model.CertificateRegenerateScope"/> values and their JSON representation.
+            </summary>
+        </member>
+        <member name="M:Pilz.PITreader.Client.Serialization.JsonCertificateRegenerateScopeConverter.Read(System.Text.Json.Utf8JsonReader@,System.Type,System.Text.Json.JsonSerializerOptions)">
+            <inheritdoc cref="M:System.Text.Json.Serialization.JsonConverter`1.Read(System.Text.Json.Utf8JsonReader@,System.Type,System.Text.Json.JsonSerializerOptions)"/>
+        </member>
+        <member name="M:Pilz.PITreader.Client.Serialization.JsonCertificateRegenerateScopeConverter.Write(System.Text.Json.Utf8JsonWriter,Pilz.PITreader.Client.Model.CertificateRegenerateScope,System.Text.Json.JsonSerializerOptions)">
+            <summary>
+            Writes a specified value as JSON.
+            </summary>
+            <param name="writer">The writer to write to.</param>
+            <param name="value">The value to convert to JSON.</param>
+            <param name="options">An object that specifies serialization options to use.</param>
         </member>
         <member name="T:Pilz.PITreader.Client.Serialization.JsonCrudActionConverter">
             <summary>

--- a/dotnet/PITreaderClient/PITreaderFirmwareManager.cs
+++ b/dotnet/PITreaderClient/PITreaderFirmwareManager.cs
@@ -80,6 +80,7 @@ namespace Pilz.PITreader.Client
                 package.Data, 
                 package.FileName, 
                 "fwFile",
+                null,
                 TimeSpan.FromMinutes(5));
 
             string hash = fileResult?.Data?.Data?.AsValue()?.GetValue<string>();

--- a/dotnet/PITreaderClient/PITreaderJsonSerializer.cs
+++ b/dotnet/PITreaderClient/PITreaderJsonSerializer.cs
@@ -38,6 +38,7 @@ namespace Pilz.PITreader.Client
 
             options.Converters.Add(new JsonVersionConverter());
             options.Converters.Add(new JsonCrudActionConverter());
+            options.Converters.Add(new JsonCertificateRegenerateScopeConverter());
             options.Converters.Add(new JsonFirmwareUpdateActionConverter());
             options.Converters.Add(new JsonSecurityIdConverter());
             options.Converters.Add(new JsonNullableDateTimeConverter());

--- a/dotnet/PITreaderClient/Serialization/JsonCertificateRegenerateScopeConverter.cs
+++ b/dotnet/PITreaderClient/Serialization/JsonCertificateRegenerateScopeConverter.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) 2022 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Pilz.PITreader.Client.Model;
+
+namespace Pilz.PITreader.Client.Serialization
+{
+    /// <summary>
+    /// Converts between <see cref="CertificateRegenerateScope"/> values and their JSON representation.
+    /// </summary>
+    public class JsonCertificateRegenerateScopeConverter : JsonConverter<CertificateRegenerateScope>
+    {
+        /// <inheritdoc cref="JsonConverter{T}.Read(ref Utf8JsonReader, Type, JsonSerializerOptions)"/>
+        public override CertificateRegenerateScope Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var names = Enum.GetNames(typeof(CertificateRegenerateScope)).Select(x => x.ToLowerInvariant()).ToList();
+            var value = reader.GetString().ToLowerInvariant();
+            var index = names.IndexOf(value);
+            if (index >= 0) return (CertificateRegenerateScope)(Enum.GetValues(typeof(CertificateRegenerateScope)).GetValue(index));
+            return default;
+        }
+
+        /// <summary>
+        /// Writes a specified value as JSON.
+        /// </summary>
+        /// <param name="writer">The writer to write to.</param>
+        /// <param name="value">The value to convert to JSON.</param>
+        /// <param name="options">An object that specifies serialization options to use.</param>
+        public override void Write(Utf8JsonWriter writer, CertificateRegenerateScope value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString().ToLowerInvariant());
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Commands/ListCommand.cs
+++ b/dotnet/PITreaderCommissioningTool/Commands/ListCommand.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Network;
+
+namespace Pilz.PITreader.CommissioningTool.Commands
+{
+    internal class ListCommand : Command
+    {
+        public ListCommand() 
+            : base("list", "Lists all devices on connected networks")
+        {
+            var scanTimeoutOption = new Option<ushort>(new[] { "--scan-timeout", "-t" }, getDefaultValue: () => 5, "Timemout for network scan operation in seconds");
+            this.AddOption(scanTimeoutOption);
+
+            this.SetHandler(context =>
+            {
+                ushort timeout = context.ParseResult.GetValueForOption(scanTimeoutOption);
+                return this.HandleCommand(context.Console, timeout);
+            });
+        }
+
+        private async Task HandleCommand(IConsole console, ushort timeout)
+        {
+            var devices = new List<PITreaderScanResult>();
+            var scan = new PITreaderNetworkScan(null);
+
+            scan.DeviceDiscovered += (_, e) => {
+                var existing = devices.FirstOrDefault(d => d.Equals(e.Device));
+                if (existing == null)
+                {
+                    devices.Add(e.Device);
+                }
+                else
+                {
+                    existing.Update(e.Device);
+                }
+            };
+
+            scan.Start();
+            do
+            {
+                scan.Query();
+                await Task.Delay(1000);
+
+                if (timeout > 0)
+                {
+                    timeout -= 1;
+                }
+            }
+            while (timeout > 0);
+            scan.Stop();
+
+            if (devices.Count > 0)
+            {
+                console.WriteLine("---------------------------------------------------------------------------------");
+                console.WriteLine("| Order number | Serial number | MAC address       | IP address    | HTTPS port |");
+                console.WriteLine("---------------------------------------------------------------------------------");
+                foreach (var device in devices)
+                {
+                    Console.WriteLine($"| {device.OrderNumber,-12} | {device.SerialNumber,-13} | {device.MacAddress,-17} | {device.IpAddress,-13} | {device.HttpsPort,-10} |");
+                }
+                console.WriteLine("---------------------------------------------------------------------------------");
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Commands/RunCommand.cs
+++ b/dotnet/PITreaderCommissioningTool/Commands/RunCommand.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Pilz.PITreader.CommissioningTool.Tasks;
+
+namespace Pilz.PITreader.CommissioningTool.Commands
+{
+    internal class RunCommand : Command
+    {
+        private const string helpDescription = @"Performs commissioning of a PITreader device
+
+Exit codes:
+  0 - all tasks successfully executed
+  1 - execution failed and was aborted
+  2 - one or more tasks failed, but execution of other tasks continued
+";
+
+        private IList<ICommissioningTask> tasks = new List<ICommissioningTask>
+        {
+            new ScanAndSetupTask(),
+
+            new FirmwareUpdateTask(),
+
+            new ConfigurationFileTask(),
+
+            // all tasks manpulating the configuration file go here
+            new CommissioningUserTask(),
+            new GenerateUserSecretsTask(),
+            new OpcUaClientCertificateTask(),
+
+            new RestoreConfigurationTask(),
+
+            new CodingTask(),
+            new TlsCertificateTask(),
+            new OpcUaServerCertificateTask(),
+            new ConfigurationBackupTask(),
+
+            new CommissioningUserCleanupTask()
+        };
+
+        public RunCommand()
+            : base("run", helpDescription)
+        {
+            foreach (var task in this.tasks)
+            {
+                foreach (var symbol in task.Options)
+                {
+                    this.AddOption(symbol);
+                }
+            }
+
+            this.SetHandler((InvocationContext context) => this.HandleCommand(context));
+        }
+
+        private async Task HandleCommand(
+            InvocationContext context)
+        {
+            var taskContext = new TaskContext(context);
+
+            // Check command line options
+            foreach (var task in this.tasks)
+            {
+                if (!task.CheckOptions(taskContext))
+                {
+                    context.ExitCode = 1;
+                    return;
+                }
+            }
+
+            // Run tasks
+            foreach (var task in this.tasks)
+            {
+                await task.RunAsync(taskContext);
+
+                if (context.ExitCode == 1)
+                {
+                    // Skip further tasks, if fatal error occured
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/CommissioningUser.cs
+++ b/dotnet/PITreaderCommissioningTool/CommissioningUser.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.CommissioningTool
+{
+    /// <summary>
+    /// User for device access during the commissioning operation.
+    /// </summary>
+    internal class CommissioningUser
+    {
+        /// <summary>
+        /// Creates a new commissioning user instance.
+        /// </summary>
+        /// <param name="name"></param>
+        public CommissioningUser(string name)
+        {
+            this.Name = name;
+        }
+
+        /// <summary>
+        /// The user name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// If set to true, username and password based interactive login is used.
+        /// Otherwise authentication via an API token is used.
+        /// </summary>
+        public bool InteractiveLogin { get; set; }
+
+        /// <summary>
+        /// Password or API token.
+        /// </summary>
+        public string? PasswordOrApiToken { get; set; }
+
+        /// <summary>
+        /// If set to true, the user with specified name should be deleted at the end of the commissioning process from the device.
+        /// </summary>
+        public bool DeleteOnCleanup { get; set; }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Extensions.cs
+++ b/dotnet/PITreaderCommissioningTool/Extensions.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Client;
+using Pilz.PITreader.Client.Model;
+using Pilz.PITreader.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool
+{
+    internal static class Extensions
+    {
+        private const string RestoreEndpoint = "/api/files/restore";
+
+        public static void WriteError(this IConsole console, string message)
+        {
+            if (!Console.IsOutputRedirected) Console.ForegroundColor = ConsoleColor.Red;
+            console.Error.Write("ERROR: " + message + Environment.NewLine);
+            if (!Console.IsOutputRedirected) Console.ResetColor();
+        }
+
+        public static async Task<string> GetCurrentThumbprintAsync(string hostnameOrIp, ushort httpsPort)
+        {
+            var certificate = await PITreaderClient.GetDeviceCertificateAsync(hostnameOrIp, httpsPort);
+
+            using (var sha2 = System.Security.Cryptography.SHA256.Create())
+            {
+                byte[] sha2Thumbprint = sha2.ComputeHash(certificate.GetRawCertData());
+                return string.Join(":", sha2Thumbprint.Select(d => d.ToString("X2")));
+            }
+        }
+
+        public async static Task<ApiResponse<GenericResponse>> RestoreConfigurationAsync(this PITreaderClient client, ConfigurationFile config)
+        {
+            using (var ms = new MemoryStream())
+            {
+                config.Write(ms);
+
+                ms.Position = 0;
+
+                return await client.PostFileAsync<GenericResponse>(
+                    RestoreEndpoint,
+                    ms,
+                    "restore.config",
+                    "configFile",
+                    config.GetRequstParameters().Select(p => new KeyValuePair<string, string>(p, "true")),
+                    TimeSpan.FromSeconds(30));
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/NetworkInterfaceService.cs
+++ b/dotnet/PITreaderCommissioningTool/NetworkInterfaceService.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.Net;
+using System.Net.NetworkInformation;
+using Makaretu.Dns;
+
+namespace Pilz.PITreader.CommissioningTool
+{
+    internal class NetworkInterfaceService
+    {
+        public static IEnumerable<NetworkInterface> GetMatchingInterfaces(IPAddress targetAddress)
+        {
+            var nics = MulticastService.GetNetworkInterfaces();
+
+            foreach (var nic in nics)
+            {
+                var properties = nic.GetIPProperties();
+                if (properties.UnicastAddresses.Any(a => IPNetwork.Parse(a.Address, a.IPv4Mask).Contains(targetAddress)))
+                        yield return nic;
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/PITreaderCommissioningTool.csproj
+++ b/dotnet/PITreaderCommissioningTool/PITreaderCommissioningTool.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Pilz.PITreader.CommissioningTool</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PITreaderClient\PITreaderClient.csproj" />
+    <ProjectReference Include="..\PITreaderConfiguration\PITreaderConfiguration.csproj" />
+    <ProjectReference Include="..\PITreaderNetwork\PITreaderNetwork.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/PITreaderCommissioningTool/PITreaderInteractiveClient.cs
+++ b/dotnet/PITreaderCommissioningTool/PITreaderInteractiveClient.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.Net;
+using Pilz.PITreader.Client;
+using Pilz.PITreader.Client.Model;
+
+namespace Pilz.PITreader.CommissioningTool
+{
+    internal class PITreaderInteractiveClient : PITreaderClient
+    {
+        public const string DefaultUsername = "admin";
+
+        private const string InteractiveLoginEndpoint = "/api/login";
+
+        private CookieContainer cookies = new CookieContainer();
+
+        /// <inheritdoc/>
+        public PITreaderInteractiveClient(string hostnameOrIp = DefaultIp, ushort portNumber = DefaultPortNumber, CertificateValidationDelegate? certificateValidation = null)
+            : base(hostnameOrIp, portNumber, certificateValidation)
+        {
+            this.handler.CookieContainer = this.cookies;
+            this.handler.UseCookies = true;
+        }
+
+        public async Task<ApiResponse<GenericResponse>> LoginAsync(string username = DefaultUsername, string password = "")
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, InteractiveLoginEndpoint);
+            var dict = new Dictionary<string, string>
+            {
+                { "user", username },
+                { "password", password }
+            };
+
+            request.Content = new FormUrlEncodedContent(dict);
+            return await this.ExecuteRequest<GenericResponse>(this.client, request);
+        }
+
+        protected override Task<ApiResponse<T>> ExecuteRequest<T>(HttpClient client, HttpRequestMessage message)
+        {
+            if (message != null && message.Method == HttpMethod.Post)
+            {
+                var xsrfCookie = (client.BaseAddress == null
+                    ? this.cookies.GetAllCookies()
+                    : this.cookies.GetCookies(client.BaseAddress)).FirstOrDefault(c => c.Name == "XSRF-TOKEN");
+
+                if (xsrfCookie != null)
+                {
+                    message.Headers.Add("X-Xsrf-Token", xsrfCookie.Value);
+                }
+            }
+
+            return base.ExecuteRequest<T>(client, message);
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/PasswordGenerator.cs
+++ b/dotnet/PITreaderCommissioningTool/PasswordGenerator.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.Security.Cryptography;
+
+namespace Pilz.PITreader.CommissioningTool
+{
+    internal class PasswordGenerator
+    {
+        private const string UpperCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        private const string LowerCharacters = "abcdefghijklmnopqrstuvwxyz";
+
+        private const string NumericCharacters = "0123456789";
+
+        private const string SpecialCharacters = "!\"§$%&/()=?+#*{[]}\\<>|.:,;-_";
+
+        public const string DefaultPasswordCharacters = LowerCharacters + UpperCharacters + NumericCharacters + SpecialCharacters;
+
+        public static string GenerateSecurePassword(int length, string characters = DefaultPasswordCharacters)
+        {
+            var buffer = new char[length];
+
+            do
+            {
+                for (int index = 0; index < length; index++)
+                {
+                    buffer[index] = characters[RandomNumberGenerator.GetInt32(characters.Length)];
+                }
+            } while (!buffer.Any(c => UpperCharacters.Contains(c))
+                    || !buffer.Any(c => LowerCharacters.Contains(c))
+                    || !buffer.Any(c => NumericCharacters.Contains(c))
+                    || !buffer.Any(c => SpecialCharacters.Contains(c)));
+
+            return new string(buffer);
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Program.cs
+++ b/dotnet/PITreaderCommissioningTool/Program.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using Pilz.PITreader.CommissioningTool.Commands;
+
+namespace Pilz.PITreader.CommissioningTool
+{
+    internal class Program
+    {
+        private static int Main(string[] args)
+        {
+            var rootCommand = new RootCommand("Tool to automate commissioning of PITreader devices");
+
+            rootCommand.AddCommand(new ListCommand());
+            rootCommand.AddCommand(new RunCommand());
+
+            return new CommandLineBuilder(rootCommand)
+                .UseDefaults()
+                .UseHelp()
+                .UseExceptionHandler(HandleException)
+                .Build()
+                .Invoke(args);
+        }
+
+        internal static void HandleException(Exception exception, InvocationContext context)
+        {
+            try
+            {
+                if (!(exception is OperationCanceledException))
+                {
+                    context.Console.WriteError(exception.Message);
+                }
+
+                context.ExitCode = 1;
+            }
+            catch
+            {
+                // pass
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Properties/launchSettings.json
+++ b/dotnet/PITreaderCommissioningTool/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "PITreaderCommissioningTool": {
+      "commandName": "Project",
+      "commandLineArgs": "run --scan-timeout=10 --set-ip=192.168.0.16 --set-netmask=255.255.255.0 --set-gateway=0.0.0.0 --config=C:\\temp\\commissioning\\PITreader_default.config --generate-api-token=UAS --config-strip-network --commissioning-user=factory --upload-certificate=C:\\Users\\p.schuster\\Documents\\CSRs\\192.168.0.16.pem --opc-ua-client-certificate=%APPDATA%\\unifiedautomation\\uaexpert\\PKI\\own\\certs\\uaexpert.der --opc-ua-server-certificate-destination=C:\\temp\\commissioning\\opua-server-cert.der --config-backup-destination=C:\\temp\\commissioning\\new.config",
+      "remoteDebugEnabled": false
+    }
+  }
+}

--- a/dotnet/PITreaderCommissioningTool/README.md
+++ b/dotnet/PITreaderCommissioningTool/README.md
@@ -1,0 +1,74 @@
+﻿# PITreader Commissioning Tool
+
+The `PITreaderCommissioningTool` is a small helper to commission/setup PITreader devices from initial unboxing to fully configured state for operation.
+
+It is designed for usage in automated in environment and only a command line tool.
+
+The tool has two commands:
+- `list` can be used to scan the network for PITreader devices and just outputs a list of all found devices
+- `run` is the main command to setup a device
+
+## list command
+
+Output of `PITreaderCommissioningTool list -h`
+
+```
+Description:
+  Lists all devices on connected networks
+
+Usage:
+  PITreaderCommissioningTool list [options]
+
+Options:
+  -t, --scan-timeout <scan-timeout>  Timemout for network scan operation in seconds [default: 5]
+  -?, -h, --help                     Show help and usage information
+```
+
+### Example output
+
+```
+---------------------------------------------------------------------------------
+| Order number | Serial number | MAC address       | IP address    | HTTPS port |
+---------------------------------------------------------------------------------
+| 402321       | 100487526     | 9C:69:B4:50:0E:39 | 192.168.0.16  | 443        |
+---------------------------------------------------------------------------------
+```
+
+## run command
+
+Output of `PITreaderCommissioningTool list -h`
+
+```
+Description:
+  Performs commissioning of device
+
+Usage:
+  PITreaderCommissioningTool run [options]
+
+Options:
+  -t, --scan-timeout <scan-timeout>                       Timemout for network scan operation in seconds [default: 5]
+  --set-ip <ip address>                                   Target ip address
+  --set-netmask <netmask>                                 Target netmask [default: 255.255.255.0]
+  --set-gateway <ip address>                              Target default gateway [default: 0.0.0.0]
+  --firmware <path to file>                               Path to latest firmware update
+  --config <path to file>                                 Configuration file to be restored
+  --config-strip-network                                  If set, the network settings are stripped from the
+                                                          configuration file before restore [default: False]
+  --commissioning-user <name>                             User created during commissioning process to access the system
+  --generate-password <name1 [name2 [name3]]>             Names of user for which passwords should be generated
+  --generate-api-token <name1 [name2 [name3]]>            Names of user for which API tokens should be generated
+  --opc-ua-client-certificate <path to file>              Path to a OPC UA client certificate that should be uploaded
+                                                          to the device
+  --coding <path to file>                                 Coding identifier (first line) and optional comment (second
+                                                          line)
+  --coding-oem <path to file>                             OEM coding identifier (first line) and optional comment
+                                                          (second line)
+  --upload-certificate <path to file>                     Path to a TLS certificate file (PEM incl. key) to be uploaded
+                                                          to the device
+  --regenerate-certificate                                If set, the certificate is regenerated after changing the IP
+                                                          address [default: False]
+  --opc-ua-server-certificate-destination <path to file>  Path to which the OPC UA server certificate should be exported
+  --config-backup-destination <path to file>              Path to which the backup of the device configuration should
+                                                          be exported
+  -?, -h, --help                                          Show help and usage information
+```

--- a/dotnet/PITreaderCommissioningTool/TaskContext.cs
+++ b/dotnet/PITreaderCommissioningTool/TaskContext.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Diagnostics.CodeAnalysis;
+using Pilz.PITreader.Client;
+using Pilz.PITreader.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool
+{
+    /// <summary>
+    /// Task execution context.
+    /// </summary>
+    internal class TaskContext
+    {
+        private PITreaderClient? client = null;
+
+        private string? clientThumbprint;
+
+        public TaskContext(InvocationContext context)
+        {
+            this.Invocation = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public string DeviceIp { get; set; } = PITreaderClient.DefaultIp;
+
+        public ushort HttpsPort { get; set; } = PITreaderClient.DefaultPortNumber;
+
+        public ConfigurationFile ConfigurationFile { get; } = new ConfigurationFile();
+
+        public CommissioningUser? ApiUser { get; set; }
+
+        public InvocationContext Invocation { get; }
+
+        [return: MaybeNull]
+        public T GetValue<T>(Option<T> option)
+        {
+            return this.Invocation.ParseResult.GetValueForOption(option);
+        }
+
+        public async Task<PITreaderClient> GetClientAsync()
+        {
+            if (this.client == null)
+            {
+                if (this.clientThumbprint is null)
+                {
+                    await this.RefetchCertificateThumbprintAsync();
+                }
+
+                if (ApiUser?.InteractiveLogin == true)
+                {
+                    var iaClient = new PITreaderInteractiveClient(DeviceIp, HttpsPort, CertificateValidators.AcceptThumbprintSha2(this.clientThumbprint));
+                    var response = await iaClient.LoginAsync(this.ApiUser.Name, this.ApiUser.PasswordOrApiToken ?? string.Empty);
+                    if (!response.Success)
+                    {
+                        this.LogError("Login at PITreader failed.");
+                        return iaClient;
+                    }
+
+                    this.client = iaClient;
+                }
+                else
+                {
+                    this.client = new PITreaderClient(this.DeviceIp, this.HttpsPort, CertificateValidators.AcceptThumbprintSha2(this.clientThumbprint));
+                    this.client.ApiToken = ApiUser?.PasswordOrApiToken ?? string.Empty;
+                }
+            }
+
+            return this.client;
+        }
+
+        public async Task RefetchCertificateThumbprintAsync()
+        {
+            this.clientThumbprint = await Extensions.GetCurrentThumbprintAsync(this.DeviceIp, this.HttpsPort);
+            this.LogInfo("Pin connection to certificate fingerprint: " + this.clientThumbprint);
+        }
+
+        public Task WaitForReboot()
+        {
+            this.client?.Dispose();
+            this.client = null;
+
+            // wait for reboot
+            this.LogInfo("Awaiting restart of device...");
+            return Task.Delay(15000);
+        }
+
+        public void LogInfo(string message)
+        {
+            this.Invocation.Console.WriteLine(FormatLogMessage(message));
+        }
+
+        public void LogError(string message)
+        {
+            if (!this.Invocation.Console.IsErrorRedirected) Console.ForegroundColor = ConsoleColor.Red;
+            this.Invocation.Console.Error.Write(FormatLogMessage("ERROR: " + message) + Environment.NewLine);
+            if (!this.Invocation.Console.IsErrorRedirected) Console.ResetColor();
+        }
+
+        private static string FormatLogMessage(string input)
+        {
+            return $"[{DateTime.Now.ToLongTimeString()}] {input}";
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/CodingTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/CodingTask.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Client;
+using Pilz.PITreader.Client.Model;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class CodingTask : ICommissioningTask
+    {
+        private Option<FileInfo> codingOption = new Option<FileInfo>(new[] { "--coding" }, "Coding identifier (first line) and optional comment (second line)")
+        {
+            ArgumentHelpName = "path to file",
+            IsRequired = false
+        };
+        
+        private Option<FileInfo> codingOemOption = new Option<FileInfo>(new[] { "--coding-oem" }, "OEM coding identifier (first line) and optional comment (second line)")
+        {
+            ArgumentHelpName = "path to file",
+            IsRequired = false
+        };
+
+        public CodingTask()
+        {
+            this.codingOption.ExistingOnly();
+            this.codingOemOption.ExistingOnly();
+        }
+
+        public Option[] Options => new Option[] { codingOption, codingOemOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            return true;
+        }
+
+        public async Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? coding = context.GetValue(codingOption);
+            if (coding != null)
+            {
+                context.LogInfo("Reading coding file...");
+
+                string? codingComment = null;
+                string? codingId = this.ReadCodingFile(coding, ref codingComment);
+
+                if (codingId != null)
+                {
+                    var model = new BasicCodingRequest
+                    {
+                        Identifier = codingId
+                    };
+
+                    if (codingComment != null)
+                    {
+                        model.Comment = codingComment;
+                    }
+
+                    context.LogInfo("Setting basic coding...");
+                    var response = await (await context.GetClientAsync()).SetBasicCoding(model);
+                    if (response == null || !response.Success)
+                    {
+                        context.LogError("Unable to set basic coding.");
+                        context.Invocation.ExitCode = 2;
+                    }
+                }
+            }
+
+            FileInfo? codingOem = context.GetValue(codingOemOption);
+            if (codingOem != null)
+            {
+                context.LogInfo("Reading oem coding file...");
+
+                string? codingComment = null;
+                string? codingId = this.ReadCodingFile(codingOem, ref codingComment);
+
+                if (codingId != null)
+                {
+                    var model = new OemCodingRequest
+                    {
+                        OldIdentifier = string.Empty,
+                        NewIdentifier = codingId
+                    };
+
+                    if (codingComment != null)
+                    {
+                        model.Comment = codingComment;
+                    }
+
+                    context.LogInfo("Setting oem coding...");
+                    var response = await (await context.GetClientAsync()).SetOemCoding(model);
+                    if (response == null || !response.Success)
+                    {
+                        context.LogError("Unable to set oem coding.");
+                        context.Invocation.ExitCode = 2;
+                    }
+                }
+            }
+        }
+
+        private string? ReadCodingFile(FileInfo file, ref string? comment)
+        {
+            using (var fs = file.OpenRead())
+            {
+                using (var reader = new StreamReader(fs))
+                {
+                    string? id = reader.ReadLine();
+
+                    if (!reader.EndOfStream)
+                    {
+                        comment = reader.ReadLine();
+                    }
+
+                    return id;
+                }
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/CommissioningUserCleanupTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/CommissioningUserCleanupTask.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class CommissioningUserCleanupTask : ICommissioningTask
+    {
+        public Option[] Options => new Option[0];
+
+        public bool CheckOptions(TaskContext context)
+        {
+            return true;
+        }
+
+        public async Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.ApiUser?.DeleteOnCleanup == true)
+            {
+                var configurationFile = new ConfigurationFile
+                {
+                    new DeviceUserFile(context.ConfigurationFile.Get<DeviceUserFile>().Users.Where(u => u.Name != context.ApiUser?.Name))
+                };
+
+                context.LogInfo($"Removing previously created commissioning user \"{context.ApiUser?.Name}\"...");
+                var fileResponse = await (await context.GetClientAsync()).RestoreConfigurationAsync(configurationFile);
+                if (!fileResponse.Success)
+                {
+                    context.LogError("Restoring configuration failed.");
+                    context.Invocation.ExitCode = 2;
+                }
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/CommissioningUserTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/CommissioningUserTask.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Configuration.Model;
+using Pilz.PITreader.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class CommissioningUserTask : ICommissioningTask
+    {
+        public Option<string?> CommissioningUserOption = new Option<string?>(new[] { "--commissioning-user" }, "User created during commissioning process to access the system")
+        {
+            ArgumentHelpName = "name"
+        };
+
+        public Option[] Options => new Option[] { this.CommissioningUserOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            return true;
+        }
+
+        public Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            string? commissioningUser = context.GetValue(this.CommissioningUserOption);
+            if (!string.IsNullOrEmpty(commissioningUser))
+            {
+                var userFile = context.ConfigurationFile.Get<DeviceUserFile>();
+                if (userFile == null)
+                {
+                    userFile = new DeviceUserFile();
+                    context.ConfigurationFile.Add(userFile);
+                }
+
+                context.ApiUser = new CommissioningUser(commissioningUser)
+                {
+                    InteractiveLogin = false
+                };
+
+                var apiUser = userFile.Users.FirstOrDefault(u => u.Name == commissioningUser);
+                if (apiUser == null)
+                {
+                    apiUser = DeviceUser.CreateNew(commissioningUser);
+                    apiUser.Role = DeviceUserRole.Administrator;
+                    apiUser.AuthenticationType = DeviceUserAuthType.ApiToken;
+
+                    userFile.Users.Add(apiUser);
+                    context.ApiUser.DeleteOnCleanup = true;
+                }
+
+                context.ApiUser.PasswordOrApiToken = apiUser.ApiToken;
+
+                context.LogInfo($"Added new user for commissioning: \"{commissioningUser}\"");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/ConfigurationBackupTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/ConfigurationBackupTask.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Client;
+using Pilz.PITreader.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class ConfigurationBackupTask : ICommissioningTask
+    {
+        private Option<FileInfo> configBackupDestinationOption = new Option<FileInfo>(new[] { "--config-backup-destination" }, "Path to which the backup of the device configuration should be exported")
+        {
+            ArgumentHelpName = "path to file"
+        };
+
+        public Option[] Options => new Option[] { configBackupDestinationOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? configBackupDestination = context.GetValue(this.configBackupDestinationOption);
+            if (configBackupDestination != null
+                && (configBackupDestination.Directory?.Exists != true))
+            {
+                context.LogError("Directory to configuration backup destination does not exist.");
+                return false;
+            }
+
+             return true;
+        }
+
+        public async Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? configBackupDestination = context.GetValue(this.configBackupDestinationOption);
+            if (configBackupDestination != null)
+            {
+                context.LogInfo("Getting configuration backup...");
+                var configBackup = new MemoryStream();
+
+                var response = await (await context.GetClientAsync()).GetConfigurationBackup(configBackup);
+                if (!response.Success)
+                {
+                    context.LogError("Unable to download configuration backup.");
+                    context.Invocation.ExitCode = 2;
+                    return;
+                }
+
+                configBackup.Position = 0;
+                context.ConfigurationFile.Read(configBackup);
+
+                if (context.ApiUser?.DeleteOnCleanup == true)
+                {
+                    var userFile = context.ConfigurationFile.Get<DeviceUserFile>();
+                    if (userFile != null)
+                    {
+                        var selectedUser = userFile.Users.FirstOrDefault(u => u.Name == context.ApiUser?.Name);
+                        if (selectedUser != null)
+                        {
+                            userFile.Users.Remove(selectedUser);
+                        }
+                    }
+
+                    configBackup.Dispose();
+                    configBackup = new MemoryStream();
+                    context.ConfigurationFile.Write(configBackup);
+                }
+
+                context.LogInfo("Copying configuration backup to file system...");
+                using (var fs = configBackupDestination.Open(FileMode.Create, FileAccess.Write))
+                {
+                    configBackup.Position = 0;
+                    configBackup.CopyTo(fs);
+                }
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/ConfigurationFileTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/ConfigurationFileTask.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Configuration.Model;
+using Pilz.PITreader.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class ConfigurationFileTask : ICommissioningTask
+    {
+        private Option<FileInfo> configOption = new Option<FileInfo>(new[] { "--config" }, "Configuration file to be restored")
+        {
+            ArgumentHelpName = "path to file"
+        };
+
+        private Option<bool> configStripNetworkOption = new Option<bool>(new[] { "--config-strip-network" }, getDefaultValue: () => false, "If set, the network settings are stripped from the configuration file before restore");
+
+        public ConfigurationFileTask()
+        {
+            this.configOption.ExistingOnly();
+        }
+
+        public Option[] Options => new Option[] { this.configOption, this.configStripNetworkOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? config = context.GetValue(this.configOption);
+            bool configStripNetwork = context.GetValue(this.configStripNetworkOption);
+            if (config == null && configStripNetwork)
+            {
+                context.LogError("No configuration file specified, but option to strip network settings.");
+                return false;
+            }
+
+            return true;
+        }
+
+        public Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? configFile = context.GetValue(this.configOption);
+            bool configStripNetwork = context.GetValue(this.configStripNetworkOption);
+
+            if (configFile != null)
+            {
+                context.LogInfo("Reading configuration file...");
+                using (var stream = configFile.OpenRead())
+                {
+                    context.ConfigurationFile.Read(stream);
+                }
+
+                if (configStripNetwork)
+                {
+                    var settings = context.ConfigurationFile.Get<SettingsFile>();
+                    if (settings != null)
+                    {
+                        var networkSettingIds = new[]
+                        {
+                            SettingsParameter.TCPIP_IP_ADDRESS,
+                            SettingsParameter.TCPIP_IP_SUBNETMASK,
+                            SettingsParameter.TCPIP_IP_GATEWAY
+                        };
+
+                        settings.Parameter.RemoveAll(p => networkSettingIds.Contains(p.Id));
+
+                        context.LogInfo("Stripped network settings from configuration file...");
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/FirmwareUpdateTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/FirmwareUpdateTask.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Client;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class FirmwareUpdateTask : ICommissioningTask
+    {
+        private Option<FileInfo> firmwareOption = new Option<FileInfo>(new[] { "--firmware" }, "Path to latest firmware update")
+        {
+            ArgumentHelpName = "path to file",
+            IsRequired = false
+        };
+
+        private Option<bool> forceFirmwareUpdateOption = new Option<bool>(new[] { "--force-firmware-update" }, "If set the update is always performed. Otherwise only on upgrades.");
+
+        public FirmwareUpdateTask()
+        {
+            this.firmwareOption.ExistingOnly();
+        }
+
+        public Option[] Options => new Option[] { this.firmwareOption, this.forceFirmwareUpdateOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? firmwareUpdate = context.GetValue(this.firmwareOption);
+            bool forceUpdate = context.GetValue(this.forceFirmwareUpdateOption);
+            if (firmwareUpdate == null && forceUpdate)
+            {
+                context.LogError("No firmware update file specified, but option to force the update.");
+                return false;
+            }
+
+            return true;
+        }
+
+        public async Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? firmwareUpdate = context.GetValue(this.firmwareOption);
+            bool forceUpdate = context.GetValue(this.forceFirmwareUpdateOption);
+            if (firmwareUpdate != null)
+            {
+                context.LogInfo("Reading firmware update package...");
+                var fwu = new PITreaderFirmwarePackage(firmwareUpdate.FullName);
+                var fwManager = new PITreaderFirmwareManager(await context.GetClientAsync());
+
+                context.LogInfo("Applying firmware update...");
+                var fwResponse = await fwManager.PerformUpdateAsync(fwu, forceUpdate);
+                if (fwResponse != PITreaderFirmwareUpdateResult.Success && fwResponse != PITreaderFirmwareUpdateResult.AlreadyInstalledOrNewer)
+                {
+                    context.LogError("Applying firmware update failed.");
+                    context.Invocation.ExitCode = 2;
+                }
+
+                if (fwResponse == PITreaderFirmwareUpdateResult.Success)
+                {
+                    await context.WaitForReboot();
+                }
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/GenerateUserSecretsTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/GenerateUserSecretsTask.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Configuration.Model;
+using Pilz.PITreader.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class GenerateUserSecretsTask : ICommissioningTask
+    {
+        private Option<IEnumerable<string>> generatePasswordOption = new Option<IEnumerable<string>>(new[] { "--generate-password" }, "Names of user for which passwords should be generated")
+        {
+            ArgumentHelpName = "name1 [name2 [name3]]",
+            Arity = ArgumentArity.ZeroOrMore,
+            AllowMultipleArgumentsPerToken = true
+        };
+
+        private Option<IEnumerable<string>> generateApiTokenOption = new Option<IEnumerable<string>>(new[] { "--generate-api-token" }, "Names of user for which API tokens should be generated")
+        {
+            ArgumentHelpName = "name1 [name2 [name3]]",
+            Arity = ArgumentArity.ZeroOrMore,
+            AllowMultipleArgumentsPerToken = true
+        };
+
+        public Option[] Options => new Option[] { this.generatePasswordOption, this.generateApiTokenOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            return true;
+        }
+
+        public Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            IEnumerable<string> generatePassword = context.GetValue(this.generatePasswordOption) ?? Enumerable.Empty<string>();
+            IEnumerable<string> generateApiToken = context.GetValue(this.generateApiTokenOption) ?? Enumerable.Empty<string>();
+
+            if (generatePassword != null && generatePassword.Any(x => !string.IsNullOrWhiteSpace(x)))
+            {
+                var userFile = context.ConfigurationFile.Get<DeviceUserFile>();
+                if (userFile == null)
+                {
+                    context.LogError("No user file in config restore for generating passwords for user.");
+                    return Task.CompletedTask;
+                }
+
+                foreach (string userName in generatePassword.Where(x => !string.IsNullOrWhiteSpace(x)))
+                {
+                    DeviceUser? user = userFile.Users.FirstOrDefault(u => u.Name == userName);
+                    if (user == null)
+                    {
+                        context.LogError($"No user named \"{userName}\" in user file in config restore for generating password.");
+                    }
+                    else
+                    {
+                        string password = PasswordGenerator.GenerateSecurePassword(12);
+                        user.SetPassword(password);
+                        context.LogInfo($"Generated new password for user {userName}: {password}");
+                    }
+                }
+            }
+
+            if (generateApiToken != null && generateApiToken.Any(x => !string.IsNullOrWhiteSpace(x)))
+            {
+                var userFile = context.ConfigurationFile.Get<DeviceUserFile>();
+                if (userFile == null)
+                {
+                    context.LogError("No user file in config restore for generating passwords for user.");
+                    return Task.CompletedTask;
+                }
+
+                foreach (string userName in generateApiToken.Where(x => !string.IsNullOrWhiteSpace(x)))
+                {
+                    DeviceUser? user = userFile.Users.FirstOrDefault(u => u.Name == userName);
+                    if (user == null)
+                    {
+                        context.LogError($"No user named \"{userName}\" in user file in config restore for generating API token.");
+                    }
+                    else
+                    {
+                        user.RegenerateApiToken();
+                        context.LogInfo($"Generated new API token for user {userName}: {user.ApiToken}");
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/ICommissioningTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/ICommissioningTask.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    /// <summary>
+    /// Commissioning task
+    /// </summary>
+    internal interface ICommissioningTask
+    {
+        /// <summary>
+        /// List of options for this commissioning task
+        /// </summary>
+        Option[] Options { get; }
+
+        /// <summary>
+        /// Checks the values of the provided command line options 
+        /// </summary>
+        /// <param name="context">The task execution context.</param>
+        /// <returns>True, if all checked options are valid. Otherwise false.</returns>
+        bool CheckOptions(TaskContext context);
+
+        /// <summary>
+        /// Runs the task.
+        /// </summary>
+        /// <param name="context">The task execution context.</param>
+        /// <returns></returns>
+        Task RunAsync(TaskContext context);
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/OpcUaClientCertificateTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/OpcUaClientCertificateTask.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class OpcUaClientCertificateTask : ICommissioningTask
+    {
+        private Option<FileInfo> opcUaClientCertificateOption = new Option<FileInfo>(new[] { "--opc-ua-client-certificate" }, "Path to a OPC UA client certificate that should be uploaded to the device")
+        {
+            ArgumentHelpName = "path to file",
+            IsRequired = false
+        };
+
+        public OpcUaClientCertificateTask()
+        {
+            this.opcUaClientCertificateOption.ExistingOnly();
+        }
+
+        public Option[] Options => new Option[] { opcUaClientCertificateOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            return true;
+        }
+
+        public Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? opcUaClientCertificate = context.GetValue(opcUaClientCertificateOption);
+            if (opcUaClientCertificate != null)
+            {
+                context.LogInfo("Adding OPC UA client certificate to configuration...");
+
+                var certFile = context.ConfigurationFile.Get<OpcUaClientCertificateFile>();
+                if (certFile == null)
+                {
+                    certFile = new OpcUaClientCertificateFile();
+                    context.ConfigurationFile.Add(certFile);
+                }
+
+                using (var fs = opcUaClientCertificate.OpenRead())
+                {
+                    certFile.Read(fs);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/OpcUaServerCertificateTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/OpcUaServerCertificateTask.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Client;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class OpcUaServerCertificateTask : ICommissioningTask
+    {
+        private Option<FileInfo> opcUaServerCertificateDestinationOption = new Option<FileInfo>(new[] { "--opc-ua-server-certificate-destination" }, "Path to which the OPC UA server certificate should be exported")
+        {
+            ArgumentHelpName = "path to file"
+        };
+
+        public Option[] Options => new Option[] { opcUaServerCertificateDestinationOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? opcUaServerCertificateDestination = context.GetValue(this.opcUaServerCertificateDestinationOption);
+            if (opcUaServerCertificateDestination != null
+                && (opcUaServerCertificateDestination.Directory?.Exists != true))
+            {
+                context.LogError("Directory to OPC UA server certificate destination does not exist.");
+                return false;
+            }
+
+            return true;
+        }
+
+        public async Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? opcUaServerCertificateDestination = context.GetValue(opcUaServerCertificateDestinationOption);
+            if (opcUaServerCertificateDestination != null)
+            {
+                context.LogInfo("Copying OPC UA server certificate to file system...");
+                using (var fs = opcUaServerCertificateDestination.Open(FileMode.Create, FileAccess.Write))
+                {
+                    var response = await (await context.GetClientAsync()).GetOpcUaServerCertificate(fs);
+                    if (!response.Success)
+                    {
+                        context.LogError("Unable to download OPC UA server certificate: " + response.ResponseCode);
+                        context.Invocation.ExitCode = 2;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/RestoreConfigurationTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/RestoreConfigurationTask.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class RestoreConfigurationTask : ICommissioningTask
+    {
+        public Option[] Options => new Option[0];
+
+        public bool CheckOptions(TaskContext context)
+        {
+            return true;
+        }
+
+        public async Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            context.LogInfo("Restoring device configuration...");
+
+            var client = await context.GetClientAsync();
+            var fileResponse = await client.RestoreConfigurationAsync(context.ConfigurationFile);
+            if (!fileResponse.Success)
+            {
+                context.LogError("Restoring configuration failed.");
+                context.Invocation.ExitCode = 1;
+                return;
+            }
+
+            await context.WaitForReboot();
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/ScanAndSetupTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/ScanAndSetupTask.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using System.Net;
+using System.Net.NetworkInformation;
+using Pilz.PITreader.Client;
+using Pilz.PITreader.Network;
+using Pilz.PITreader.Network.Configuration;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class ScanAndSetupTask : ICommissioningTask
+    {
+        private Option<ushort> scanTimeoutOption = new Option<ushort>(new[] { "--scan-timeout", "-t" }, getDefaultValue: () => 5, "Timemout for network scan operation in seconds");
+
+        private Option<IPAddress> setIpOption = new Option<IPAddress>(new[] { "--set-ip" }, "Target ip address")
+        {
+            ArgumentHelpName = "ip address",
+            Arity = ArgumentArity.ExactlyOne,
+            IsRequired = true
+        };
+        
+        private Option<IPAddress> setNetmaskOption = new Option<IPAddress>(new[] { "--set-netmask" }, getDefaultValue: () => IPAddress.Parse("255.255.255.0"), "Target netmask")
+        {
+            ArgumentHelpName = "netmask",
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
+        private Option<IPAddress> setGatewayOption = new Option<IPAddress>(new[] { "--set-gateway" }, getDefaultValue: () => IPAddress.Any, "Target default gateway")
+        {
+            ArgumentHelpName = "ip address",
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
+        public Option[] Options => new Option[] { this.scanTimeoutOption, this.setIpOption, this.setNetmaskOption, this.setGatewayOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            return true;
+        }
+
+        public async Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            ushort timeout = context.GetValue(scanTimeoutOption);
+
+            IPAddress setIp = context.GetValue(this.setIpOption)!;
+            IPAddress setNetmask = context.GetValue(this.setNetmaskOption)!;
+            IPAddress setGateway = context.GetValue(this.setGatewayOption)!;
+
+            var matchingNics = NetworkInterfaceService.GetMatchingInterfaces(setIp).ToList();
+
+            context.LogInfo("Scanning for PITreader device...");
+            var device = await this.ScanNetworkAsync(timeout, matchingNics);
+            if (device == null)
+            {
+                context.LogError("Unable to find single device with default ip.");
+                context.Invocation.ExitCode = 1;
+                return;
+            }
+
+            context.LogInfo("Setting network configuration...");
+            var mcp = new ConfigurationService(matchingNics, TimeSpan.FromSeconds(5));
+            var mcpResponse = await mcp.SendAsnyc(new SetIPv4Request
+            {
+                OrderNumber = device.OrderNumber,
+                SerialNumber = device.SerialNumber,
+                DeviceIp = setIp.ToString(),
+                Netmask = setNetmask.ToString(),
+                GatewayIp = setGateway.ToString()
+            });
+
+            if (mcpResponse == null || !mcpResponse.Success)
+            {
+                context.LogError("Unable to set network configuration.");
+                context.Invocation.ExitCode = 1;
+                return;
+            }
+
+            // Update IP address for upcomming tasks
+            context.DeviceIp = setIp.ToString();
+            context.HttpsPort = device.HttpsPort;
+
+            context.ApiUser = new CommissioningUser(PITreaderInteractiveClient.DefaultUsername)
+            {
+                InteractiveLogin = true,
+                PasswordOrApiToken = device.SerialNumber,
+                DeleteOnCleanup = false
+            };
+
+            // wait for reboot
+            await context.WaitForReboot();
+
+            // Dummy call to init session
+            await context.GetClientAsync();
+        }
+
+        private async Task<PITreaderScanResult?> ScanNetworkAsync(ushort timeout, IEnumerable<NetworkInterface> matchingNics)
+        {
+            var devices = new List<PITreaderScanResult>();
+            var scan = new PITreaderNetworkScan(nics => nics.Where(n => matchingNics.Any(m => m.Id == n.Id)));
+            scan.DeviceDiscovered += (_, e) => {
+                var existing = devices.FirstOrDefault(d => d.Equals(e.Device));
+                if (existing == null)
+                {
+                    devices.Add(e.Device);
+                }
+                else
+                {
+                    existing.Update(e.Device);
+                }
+            };
+
+            scan.Start();
+            do
+            {
+                scan.Query();
+                await Task.Delay(1000);
+
+                if (timeout > 0)
+                {
+                    timeout -= 1;
+                }
+            }
+            while (timeout > 0);
+
+            return devices.SingleOrDefault(d => d.IpAddress == PITreaderClient.DefaultIp);
+        }
+    }
+}

--- a/dotnet/PITreaderCommissioningTool/Tasks/TlsCertificateTask.cs
+++ b/dotnet/PITreaderCommissioningTool/Tasks/TlsCertificateTask.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.CommandLine;
+using Pilz.PITreader.Client;
+using Pilz.PITreader.Client.Model;
+
+namespace Pilz.PITreader.CommissioningTool.Tasks
+{
+    internal class TlsCertificateTask : ICommissioningTask
+    {
+        private Option<FileInfo> uploadCertificateOption = new Option<FileInfo>(new[] { "--upload-certificate" }, "Path to a TLS certificate file (PEM incl. key) to be uploaded to the device")
+        {
+            ArgumentHelpName = "path to file"
+        };
+        
+        private Option<bool> regenerateCertificateOption = new Option<bool>(new[] { "--regenerate-certificate" }, getDefaultValue: () => false, "If set, the certificate is regenerated after changing the IP address");
+
+        public TlsCertificateTask()
+        {
+            this.uploadCertificateOption.ExistingOnly();
+        }
+
+        public Option[] Options => new Option[] { uploadCertificateOption, regenerateCertificateOption };
+
+        public bool CheckOptions(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            FileInfo? uploadCertificatePath = context.GetValue(this.uploadCertificateOption);
+            bool regenerateCertificate = context.GetValue(this.regenerateCertificateOption);
+            if (regenerateCertificate && uploadCertificatePath != null)
+            {
+                context.LogError("Cannot specify a certificate upload path as well as the option to regenerate the certificate.");
+                return false;
+            }
+
+            return true;
+        }
+
+        public async Task RunAsync(TaskContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            bool rebootAndCheck = false;
+
+            FileInfo? uploadCertificate = context.GetValue(this.uploadCertificateOption);
+            bool regenerateCertificate = context.GetValue(this.regenerateCertificateOption);
+
+            if (uploadCertificate != null)
+            {
+                context.LogInfo("Uploading TLS certificate to device...");
+                ApiResponse<GenericResponse> response;
+                using (var fs = uploadCertificate.OpenRead())
+                {
+                    response = await (await context.GetClientAsync()).UploadCertificate(fs);
+                }
+
+                if (!response.Success)
+                {
+                    context.LogError("Unable to upload TLS certificate: " + response.ResponseCode);
+                    context.Invocation.ExitCode = 2;
+                    return;
+                }
+
+                rebootAndCheck = true;
+            }
+            else if (regenerateCertificate)
+            {
+                context.LogInfo("Renewing TLS certificate of device...");
+                var response = await (await context.GetClientAsync()).RegenerateCertificate(CertificateRegenerateScope.CertOnly);
+                if (!response.Success)
+                {
+                    context.LogError("Unable to regenerate TLS certificate.");
+                    context.Invocation.ExitCode = 2;
+                    return;
+                }
+
+                rebootAndCheck = true;
+            }
+
+            if (rebootAndCheck)
+            {
+                // wait for reboot
+                await context.WaitForReboot();
+
+                context.LogInfo("Retrieving new TLS certificate thumbprint...");
+                await context.RefetchCertificateThumbprintAsync();
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration.Tests/DeviceUserFileTests.cs
+++ b/dotnet/PITreaderConfiguration.Tests/DeviceUserFileTests.cs
@@ -1,0 +1,26 @@
+using System.Text;
+
+namespace Pilz.PITreader.Configuration.Tests
+{
+    public class DeviceUserFileTests
+    {
+        [Fact]
+        public void ParseTest()
+        {
+            string inputData = "\"Name\";\"State\";\"Role\";\"Authentication Type\";\"Password Hash\";\"API Token\";\"Remote IP\"\r\n\"admin\";1;500;1;\"D15F1543CA97A1AC9B3DCB059CAB32C8DEAEDCF4B2182BC71665920539A0F00EB68DEF1FABDE2416670A90041261B2B2\";\"64366190A05B0F58ADFB157965AD6B6F\";\"\"\r\n\"UAS\";1;200;2;\"351C69AE7C6C2B9952A96ADD48C0D3EACB9BC2DD478BB0D0582D873C277E47B794DD5306C797AC00337C20802FC311A2\";\"DD5FB30B4D715C0D777EA15559989B77\";\"\"\r\n\"peter\";1;500;1;\"1C2F0D043979C1C23AD6BC392C7902C7A60C4A898FB91D7265E3CA19421FAA1AA82087CCC479A40BEB6519225F36B660\";\"A634286DC7D5C25C3142F996730D51DD\";\"\"\r\n\"CredentialProvider\";1;10;2;\"672721FE5BC1654E0E778CC75A94F7F7912E527EE9309FDC3AA775F457FB3F192202C4D588A9BC65EDFFDAEC62E3EEC3\";\"A10FF77D3A5CC69ABBD6C8E9E5F597D0\";\"192.168.0.25\"\r\n\"ansible\";1;500;2;\"E54CF93E13D2E1BD171F6AF7B80C04C6EFA7B4DE8D2034178F3B17A3B6FC0A78A7E1C5CED348AA3CB07175F7893054F8\";\"45858D5B5AF9D4DF50E3B7A6E9C0478E\";\"\"\r\n";
+
+            var ms = new MemoryStream(Encoding.ASCII.GetBytes(inputData));
+
+            var file = new DeviceUserFile();
+            file.Read(ms);
+
+            Assert.True(file.Users.Count == 5);
+
+            var writeStream = new MemoryStream();
+            file.Write(writeStream);
+
+            string outData = Encoding.ASCII.GetString(writeStream.ToArray());
+            Assert.Equal(inputData, outData);
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration.Tests/PITreaderConfiguration.Tests.csproj
+++ b/dotnet/PITreaderConfiguration.Tests/PITreaderConfiguration.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+
+    <RootNamespace>Pilz.PITreader.Configuration.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PITreaderConfiguration\PITreaderConfiguration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/PITreaderConfiguration.Tests/SettingsFileTests.cs
+++ b/dotnet/PITreaderConfiguration.Tests/SettingsFileTests.cs
@@ -1,0 +1,37 @@
+using System.Text;
+
+namespace Pilz.PITreader.Configuration.Tests
+{
+    public class SettingsFileTests
+    {
+        [Fact]
+        public void ParseTest()
+        {
+            string inputData = @"PITR_CFG
+V=01
+0x00010800, 01, 0x00
+0x00010000, 64, 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000726564616572746970
+0x00010001, 64, 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+0x00010002, 04, 0xc0a8000c
+0x00010003, 04, 0xffffff00
+0x00010004, 04, 0x00000000
+0x00010005, 48, 0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+0x00010502, 01, 0x01
+0x00010503, 04, 0x000001ff
+";
+
+            var ms = new MemoryStream(Encoding.ASCII.GetBytes(inputData));
+
+            var file = new SettingsFile();
+            file.Read(ms);
+
+            Assert.True(file.Parameter.Count == 9);
+
+            var writeStream = new MemoryStream();
+            file.Write(writeStream);
+
+            string outData = Encoding.ASCII.GetString(writeStream.ToArray());
+            Assert.Equal(inputData, outData);
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration.Tests/Usings.cs
+++ b/dotnet/PITreaderConfiguration.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/dotnet/PITreaderConfiguration/ConfigurationComponent.cs
+++ b/dotnet/PITreaderConfiguration/ConfigurationComponent.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Configuration
+{
+    public enum ConfigurationType
+    {
+        None = 0,
+        Settings = 1 << 0,
+        Blocklist = 1 << 1,
+        PermissionList = 1 << 2,
+        DevicegroupNames = 1 << 3,
+        UserDataConfiguration = 1 << 4,
+        DeviceUsers = 1 << 5,
+        OpcUaClientCertificate = 1 << 6
+    }
+}

--- a/dotnet/PITreaderConfiguration/ConfigurationFile.cs
+++ b/dotnet/PITreaderConfiguration/ConfigurationFile.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using SharpCompress.Readers;
+using SharpCompress.Writers;
+
+namespace Pilz.PITreader.Configuration
+{
+    public class ConfigurationFile : IEnumerable
+    {
+        private List<IConfigurationComponent> components = new List<IConfigurationComponent>();
+
+        public ConfigurationFile()
+        {
+        }
+
+        public void Read(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            IConfigurationComponent comp;
+
+            // Check for old file type with just settings
+            if (stream.CanSeek)
+            {
+                long position = stream.Position;
+                byte[] header = new byte[SettingsFile.Header.Length];
+                stream.Read(header, 0, header.Length);
+                stream.Position = position;
+
+                if (header.SequenceEqual(Encoding.ASCII.GetBytes(SettingsFile.Header)))
+                {
+                    comp = new SettingsFile();
+                    comp.Read(stream);
+                    this.components.Add(comp);
+                    return;
+                }
+            }
+
+            // Read tar
+            var reader = ReaderFactory.Open(stream);
+            while (reader.MoveToNextEntry())
+            {
+                if (!reader.Entry.IsDirectory)
+                {
+                    using (var ms = new MemoryStream())
+                    {
+                        reader.WriteEntryTo(ms);
+
+                        string data = Encoding.UTF8.GetString(ms.ToArray());
+                        ms.Position = 0;
+
+                        switch (reader.Entry.Key)
+                        {
+                            case SettingsFile.FileName:
+                                comp = new SettingsFile();
+                                break;
+                            case DeviceUserFile.FileName:
+                                comp = new DeviceUserFile();
+                                break;
+                            case OpcUaClientCertificateFile.FileName:
+                                comp = new OpcUaClientCertificateFile();
+                                break;
+                            default:
+                                comp = new GenericFile(reader.Entry.Key);
+                                break;
+                        }
+
+                        comp.Read(ms);
+                        this.components.Add(comp);
+                    }
+                }
+            }
+        }
+
+        public void Add(IConfigurationComponent component)
+        {
+            if (component is null)
+            {
+                throw new ArgumentNullException(nameof(component));
+            }
+
+            this.components.Add(component);
+        }
+
+        public IConfigurationComponent Get(string key)
+        {
+            return this.components.SingleOrDefault(c => c.Key == key);
+        }
+
+        public TComponent Get<TComponent>(string key = null) where TComponent : IConfigurationComponent
+        {
+            return this.components.OfType<TComponent>()
+                .Where(c => key == null || c.Key == key)
+                .FirstOrDefault();
+        }
+
+        public void Write(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            using (var writer = WriterFactory.Open(
+                stream, 
+                SharpCompress.Common.ArchiveType.Tar, 
+                new WriterOptions(SharpCompress.Common.CompressionType.None)))
+            {
+                foreach (var component in this.components)
+                {
+                    using (var ms = new MemoryStream())
+                    {
+                        component.Write(ms);
+                        ms.Position = 0;
+
+                        writer.Write(component.Key, ms);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parameters for API 
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetRequstParameters()
+        {
+            foreach (var component in this.components)
+            {
+                switch (component.Key)
+                {
+                    case SettingsFile.FileName: yield return "deviceConfig"; break;
+                    case DeviceUserFile.FileName: yield return "deviceUser"; break;
+                    case "udc.csv": yield return "userDataConfig"; break;
+                    case "bl.csv": yield return "transponderBlocklist"; break;
+                    case "dgn.csv": yield return "deviceGroupNames"; break;
+                    case "xpndrdb.csv": yield return "permissionList"; break;
+                    case OpcUaClientCertificateFile.FileName: yield return "opcuaClients"; break;
+                }
+            }
+        }
+        
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.components.GetEnumerator();
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration/DeviceUserFile.cs
+++ b/dotnet/PITreaderConfiguration/DeviceUserFile.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using CsvHelper;
+using Pilz.PITreader.Configuration.Model;
+
+namespace Pilz.PITreader.Configuration
+{
+    public class DeviceUserFile : IConfigurationComponent
+    {
+        public const string FileName = "user.csv";
+
+        public string Key => FileName;
+
+        public ConfigurationType Component { get; } = ConfigurationType.DeviceUsers;
+
+        public List<DeviceUser> Users { get; } = new List<DeviceUser>();
+
+        public DeviceUserFile()
+        {
+        }
+
+        public DeviceUserFile(IEnumerable<DeviceUser> users)
+        {
+            this.Users.AddRange(users);
+        }
+
+        public void Read(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            try
+            {
+                using (var reader = new StreamReader(stream))
+                {
+                    using (var csv = new CsvReader(reader, PITreaderCsvConfiguration.Configuration))
+                    {
+                        csv.Context.RegisterClassMap<DeviceUserMap>();
+
+                        csv.Read();
+                        try
+                        {
+                            csv.ReadHeader();
+                        }
+                        catch
+                        {
+                            //
+                        }
+
+                        var users = csv.GetRecords<DeviceUser>().ToList();
+
+                        this.Users.Clear();
+                        this.Users.AddRange(users);
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidDataException("Invalid data", exception);
+            }
+        }
+
+        public void Write(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            try
+            {
+                using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true))
+                {
+                    using (var csv = new CsvWriter(writer, PITreaderCsvConfiguration.Configuration))
+                    {
+                        csv.Context.RegisterClassMap<DeviceUserMap>();
+                        csv.WriteRecords(this.Users);
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidDataException("Invalid data", exception);
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration/EnumNumberConverter.cs
+++ b/dotnet/PITreaderConfiguration/EnumNumberConverter.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Reflection;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+using CsvHelper;
+
+namespace Pilz.PITreader.Configuration
+{
+    /// <summary>
+	/// Converts an <see cref="Enum"/> to and from a <see cref="string"/> with representation as a number.
+	/// </summary>
+    internal class EnumNumberConverter : DefaultTypeConverter
+    {
+        private readonly Type type;
+
+        /// <summary>
+        /// Creates a new <see cref="EnumNumberConverter"/> for the given <see cref="Enum"/> <see cref="System.Type"/>.
+        /// </summary>
+        /// <param name="type">The type of the Enum.</param>
+        public EnumNumberConverter(Type type)
+        {
+            if (!typeof(Enum).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+            {
+                throw new ArgumentException($"'{type.FullName}' is not an Enum.");
+            }
+
+            this.type = type;
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+        {
+            return Enum.Parse(type, text);
+        }
+
+        /// <inheritdoc/>
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+        {
+            return base.ConvertToString((int)value, row, memberMapData);
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration/GenericFile.cs
+++ b/dotnet/PITreaderConfiguration/GenericFile.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.IO;
+
+namespace Pilz.PITreader.Configuration
+{
+    public class GenericFile : IConfigurationComponent
+    {
+        public string Key { get;set;}
+
+        public ConfigurationType Component { get; set; } = ConfigurationType.None;
+
+        protected byte[] data = new byte[0];
+
+        public GenericFile(string key)
+        {
+            this.Key = key;
+
+            switch (this.Key)
+            {
+                case SettingsFile.FileName: this.Component = ConfigurationType.Settings; break;
+                case DeviceUserFile.FileName: this.Component = ConfigurationType.DeviceUsers; break;
+                case "udc.csv": this.Component = ConfigurationType.UserDataConfiguration; break;
+                case "bl.csv": this.Component = ConfigurationType.Blocklist; break;
+                case "dgn.csv": this.Component = ConfigurationType.DevicegroupNames; break;
+                case "xpndrdb.csv": this.Component = ConfigurationType.PermissionList; break;
+                case OpcUaClientCertificateFile.FileName: this.Component = ConfigurationType.OpcUaClientCertificate; break;
+            }
+        }
+
+        public void Read(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            var data = new byte[stream.Length - stream.Position];
+            stream.Read(data, 0, data.Length);
+            this.data = data;
+        }
+
+        public void Write(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            stream.Write(this.data, 0, this.data.Length);
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration/IConfigurationComponent.cs
+++ b/dotnet/PITreaderConfiguration/IConfigurationComponent.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.IO;
+
+namespace Pilz.PITreader.Configuration
+{
+    /// <summary>
+    /// Component of backup/restore file
+    /// </summary>
+    public interface IConfigurationComponent
+    {
+        /// <summary>
+        /// Component key (i.e. file name)
+        /// </summary>
+        string Key { get; }
+
+        /// <summary>
+        /// Component type
+        /// </summary>
+        ConfigurationType Component { get; }
+
+        /// <summary>
+        /// Read component from binary stream.
+        /// </summary>
+        /// <param name="stream">Binary stream from .config file.</param>
+        void Read(Stream stream);
+
+        /// <summary>
+        /// Write component to binary stream.
+        /// </summary>
+        /// <param name="stream">Destination stream (i.e. .config file)</param>
+        void Write(Stream stream);
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/DeviceUser.cs
+++ b/dotnet/PITreaderConfiguration/Model/DeviceUser.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Security.Cryptography;
+
+namespace Pilz.PITreader.Configuration.Model
+{
+    public class DeviceUser
+    {
+        public string Name { get; set; }
+
+        public DeviceUserState State { get; set; }
+
+        public DeviceUserRole Role { get; set; }
+
+        public DeviceUserAuthType AuthenticationType { get; set; }
+
+        public byte[] PasswordHash { get; set; }
+
+        public string ApiToken { get; set; }
+
+        public string RemoteIp { get; set; }
+
+        public static DeviceUser CreateNew(string name)
+        {
+            var user = new DeviceUser
+            {
+                Name = name,
+                State = DeviceUserState.Active,
+                Role = DeviceUserRole.Readonly,
+                AuthenticationType = DeviceUserAuthType.ApiToken,
+                PasswordHash = new byte[48],
+                RemoteIp = string.Empty,
+            };
+
+            var apiToken = new byte[16];
+
+            var rnd = new RNGCryptoServiceProvider();
+            rnd.GetBytes(user.PasswordHash);
+            rnd.GetBytes(apiToken);
+
+            user.ApiToken = Convert.ToBase64String(apiToken);
+            return user;
+        }
+
+        public void RegenerateApiToken()
+        {
+            var apiToken = new byte[16];
+
+            var rnd = new RNGCryptoServiceProvider();
+            rnd.GetBytes(apiToken);
+
+            this.ApiToken = Convert.ToBase64String(apiToken);
+        }
+
+        public void SetPassword(string password)
+        {
+            var salt = new byte[16];
+
+            var rnd = new RNGCryptoServiceProvider();
+            rnd.GetBytes(salt);
+
+            var pkbf2 = new Rfc2898DeriveBytes(password, salt, 1024, HashAlgorithmName.SHA256);
+            var hash = pkbf2.GetBytes(32);
+
+            salt.CopyTo(this.PasswordHash, 0);
+            hash.CopyTo(this.PasswordHash, 16);
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/DeviceUserAuthType.cs
+++ b/dotnet/PITreaderConfiguration/Model/DeviceUserAuthType.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Configuration.Model
+{
+    public enum DeviceUserAuthType
+    {
+        None = 0,
+        Password = 1,
+        ApiToken = 2
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/DeviceUserMap.cs
+++ b/dotnet/PITreaderConfiguration/Model/DeviceUserMap.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Linq;
+using CsvHelper;
+using CsvHelper.Configuration;
+
+namespace Pilz.PITreader.Configuration.Model
+{
+    internal class DeviceUserMap : ClassMap<DeviceUser>
+    {
+        public DeviceUserMap()
+        {
+            Map(m => m.Name).Name("Name");
+
+            Map(m => m.State).Name("State").TypeConverter(new EnumNumberConverter(typeof(DeviceUserState)));
+
+            Map(m => m.Role).Name("Role").TypeConverter(new EnumNumberConverter(typeof(DeviceUserRole)));
+
+            Map(m => m.AuthenticationType).Name("Authentication Type").TypeConverter(new EnumNumberConverter(typeof(DeviceUserAuthType)));
+
+            ConvertFromString<byte[]> passwordHashFromString = s =>
+            {
+                string dataString = s.Row.GetField("Password Hash");
+
+                byte[] data = new byte[dataString.Length / 2];
+                for (int index = 0; index < dataString.Length; index += 2)
+                {
+                    data[index / 2] = Convert.ToByte(dataString.Substring(index, 2), 16);
+                }
+
+                return data;
+            };
+
+            ConvertToString<DeviceUser> passwordHashToString = a =>
+            {
+                return string.Join(string.Empty, a.Value.PasswordHash.Select(d => d.ToString("X2")));
+            };
+
+            Map(m => m.PasswordHash).Name("Password Hash")
+                .Convert(passwordHashFromString)
+                .Convert(passwordHashToString);
+
+            ConvertFromString<string> apiTokenFromString = s =>
+            {
+                string dataString = s.Row.GetField("API Token");
+                
+                byte[] data = new byte[dataString.Length / 2];
+                for (int index = 0; index < dataString.Length; index += 2)
+                {
+                    data[index / 2] = Convert.ToByte(dataString.Substring(index, 2), 16);
+                }
+
+                return Convert.ToBase64String(data);
+            };
+
+            ConvertToString<DeviceUser> apiTokenToString = a =>
+            {
+                byte[] data = Convert.FromBase64String(a.Value.ApiToken);
+                return string.Join(string.Empty, data.Select(d => d.ToString("X2")));
+            };
+
+            Map(m => m.ApiToken).Name("API Token")
+                .Convert(apiTokenFromString)
+                .Convert(apiTokenToString);
+
+            Map(m => m.RemoteIp).Name("Remote IP");
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/DeviceUserRole.cs
+++ b/dotnet/PITreaderConfiguration/Model/DeviceUserRole.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Configuration.Model
+{
+    public enum DeviceUserRole
+    {
+        None = 0,
+        Readonly = 10,
+        TransponderManager = 200,
+        DeviceManager = 400,
+        Administrator = 500
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/DeviceUserState.cs
+++ b/dotnet/PITreaderConfiguration/Model/DeviceUserState.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Configuration.Model
+{
+    public enum DeviceUserState
+    {
+        Inactive = 0,
+        Active = 1
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/SettingsParameter.cs
+++ b/dotnet/PITreaderConfiguration/Model/SettingsParameter.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.Linq;
+
+namespace Pilz.PITreader.Configuration.Model
+{
+    public partial class SettingsParameter
+    {
+        public int Id { get; set; }
+
+        public int Size { get; set; }
+
+        public byte[] Data { get; set; }
+
+        public string Format()
+        {
+            return $"0x{Id:X8}, {Size:00}, 0x{string.Join(string.Empty, Data.Select(d => d.ToString("x2")))}";
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/SettingsParamter.Ids.cs
+++ b/dotnet/PITreaderConfiguration/Model/SettingsParamter.Ids.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Configuration.Model
+{
+    public partial class SettingsParameter
+    {
+        /// <summary>ip parameter ip address</summary>
+        public const int TCPIP_IP_ADDRESS = 0x10002;
+
+        /// <summary>ip parameter subnet mask</summary>
+        public const int TCPIP_IP_SUBNETMASK = 0x10003;
+
+        /// <summary>ip parameter default gateway</summary>
+        public const int TCPIP_IP_GATEWAY = 0x10004;
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/SettingsParamter.Ids.tt
+++ b/dotnet/PITreaderConfiguration/Model/SettingsParamter.Ids.tt
@@ -1,0 +1,38 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ assembly name="System.Xml"#>
+<#@ import namespace="System.Xml" #>
+<#@ output extension=".cs" #>
+// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Configuration.Model
+{
+    public partial class SettingsParameter
+    {<#
+ XmlDocument doc = new XmlDocument();
+ // Replace this file path with yours:
+ doc.Load(Host.ResolvePath(@"pitreader-settings.xml"));
+ foreach (XmlNode node in doc.SelectNodes("//*"))
+ {
+	if (node.Attributes["label"] == null || node.Attributes["name"] == null || node.Attributes["id"] == null)
+		continue;
+#>
+
+        /// <summary><#= node.Attributes["label"].Value #></summary>
+        public const int <#= node.Attributes["name"].Value #> = <#= node.Attributes["id"].Value #>;
+<#
+ }
+#>
+    }
+}

--- a/dotnet/PITreaderConfiguration/Model/pitreader-settings.xml
+++ b/dotnet/PITreaderConfiguration/Model/pitreader-settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<parameter>
+  <param name="TCPIP_IP_ADDRESS" id="0x10002" label="ip parameter ip address" type="IPv4" />
+  <param name="TCPIP_IP_SUBNETMASK" id="0x10003" label="ip parameter subnet mask" type="IPv4" />
+  <param name="TCPIP_IP_GATEWAY" id="0x10004" label="ip parameter default gateway" type="IPv4" />
+</parameter>

--- a/dotnet/PITreaderConfiguration/OpcUaClientCertificateFile.cs
+++ b/dotnet/PITreaderConfiguration/OpcUaClientCertificateFile.cs
@@ -1,0 +1,13 @@
+﻿namespace Pilz.PITreader.Configuration
+{
+    public class OpcUaClientCertificateFile : GenericFile
+    {
+        public const string FileName = "opcuacli.der";
+
+        public OpcUaClientCertificateFile() 
+            : base(FileName)
+        {
+            this.Component = ConfigurationType.OpcUaClientCertificate;
+        }
+    }
+}

--- a/dotnet/PITreaderConfiguration/PITreaderConfiguration.csproj
+++ b/dotnet/PITreaderConfiguration/PITreaderConfiguration.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <RootNamespace>Pilz.PITreader.Configuration</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
+    <PackageReference Include="SharpCompress" Version="0.33.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Model\SettingsParamter.Ids.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>SettingsParamter.Ids.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Model\SettingsParamter.Ids.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SettingsParamter.Ids.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/dotnet/PITreaderConfiguration/PITreaderCsvConfiguration.cs
+++ b/dotnet/PITreaderConfiguration/PITreaderCsvConfiguration.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+
+namespace Pilz.PITreader.Configuration
+{
+    internal class PITreaderCsvConfiguration
+    {
+        public static readonly CsvConfiguration Configuration = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            Delimiter = ";",
+            ShouldQuote = (ShouldQuoteArgs args) => !typeof(long).IsAssignableFrom(args.FieldType) && !args.FieldType.IsEnum
+        };
+    }
+}

--- a/dotnet/PITreaderConfiguration/SettingsFile.cs
+++ b/dotnet/PITreaderConfiguration/SettingsFile.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Pilz.PITreader.Configuration.Model;
+
+namespace Pilz.PITreader.Configuration
+{
+    public class SettingsFile : IConfigurationComponent
+    {
+        public const string FileName = "config.txt";
+
+        internal const string Header = "PITR_CFG";
+
+        private const string Version = "V=01";
+
+        public string Key { get; } = FileName;
+
+        public ConfigurationType Component { get; } = ConfigurationType.Settings;
+
+        public List<SettingsParameter> Parameter { get; } = new List<SettingsParameter>();
+
+        public void Read(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            var list = new List<SettingsParameter>();
+
+            using (var reader = new StreamReader(stream))
+            {
+                while (!reader.EndOfStream)
+                {
+                    string line = reader.ReadLine();
+                    if (line == Header || line == Version)
+                    {
+                        continue;
+                    }
+
+                    string[] parts = line.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+                    if (parts.Length != 3)
+                    {
+                        throw new InvalidDataException("Invalid settings line (invalid part count): " + line);
+                    }
+
+                    int id;
+                    int size;
+                    byte[] data;
+
+                    if (!int.TryParse(parts[0].Substring(2).TrimStart('0'), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out id)
+                        || !int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out size))
+                    {
+                        throw new InvalidDataException("Invalid settings line (format error): " + line);
+                    }
+
+                    string dataString = parts[2];
+                    if (!dataString.StartsWith("0x") || (dataString.Length % 2) != 0)
+                    {
+                        throw new InvalidDataException("Invalid settings line (format error): " + line);
+                    }
+
+                    data = new byte[(dataString.Length - 2) / 2];
+                    for (int index = 2; index < dataString.Length; index += 2)
+                    {
+                        data[(index - 2) / 2] = Convert.ToByte(dataString.Substring(index, 2), 16);
+                    }
+
+                    list.Add(new SettingsParameter
+                    {
+                        Id = id,
+                        Size = size,
+                        Data = data
+                    });
+                }
+            }
+
+            this.Parameter.Clear();
+            this.Parameter.AddRange(list);
+        }
+
+        public void Write(Stream stream)
+        {
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            using (var writer = new StreamWriter(stream, Encoding.ASCII, 1024, true))
+            {
+                writer.WriteLine(Header);
+                writer.WriteLine(Version);
+                foreach (var item in this.Parameter)
+                {
+                    writer.WriteLine(item.Format());
+                }
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/CommandType.cs
+++ b/dotnet/PITreaderNetwork/Configuration/CommandType.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Multicast Configuration Command Types
+    /// </summary>
+    public enum CommandType : UInt32
+    {
+        /// <summary>
+        /// None / not a command
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Identify device (flash led).
+        /// </summary>
+        Identify = 1,
+
+        /// <summary>
+        /// Set IPv4 configuration of device.
+        /// </summary>
+        SetIPv4 = 2,
+
+        /// <summary>
+        /// Ping device to check state (e.g. authentication required).
+        /// </summary>
+        Ping = 3
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/ConfigurationService.cs
+++ b/dotnet/PITreaderNetwork/Configuration/ConfigurationService.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Service for sending Multicast Configuration Protocol requests.
+    /// </summary>
+    public class ConfigurationService
+    {
+        private readonly TimeSpan timeout;
+
+        private MulticastClient client;
+
+        private List<RequestContext> pending = new List<RequestContext>();
+
+        /// <summary>
+        /// Creates a new instance of the service.
+        /// </summary>
+        /// <param name="nics">List of network interfaces.</param>
+        /// <param name="timeout">Timeout for requests (default: 2 seconds)</param>
+        public ConfigurationService(IEnumerable<NetworkInterface> nics, TimeSpan? timeout = null)
+        {
+            this.client = new MulticastClient(nics);
+            this.client.MessageReceived += this.OnUdpMessageReceived;
+            this.timeout = timeout ?? TimeSpan.FromMilliseconds(2000);
+        }
+
+        /// <summary>
+        /// Sends a request and returns the response.
+        /// </summary>
+        /// <param name="request">Configuration request.</param>
+        /// <param name="cancellationToken">Cancellation token to cancel the request before the configured timeout is reached.</param>
+        /// <returns>The response to the request or a timeout.</returns>
+        public async Task<Response> SendAsnyc(RequestPacket request, CancellationToken? cancellationToken = null)
+        {
+            byte[] data;
+            using (var ms = new MemoryStream())
+            {
+                request.Write(ms);
+                data = ms.ToArray();
+            }
+
+            Response response = null;
+            using (var context = new RequestContext(request))
+            {
+                lock (this.pending)
+                {
+                    this.pending.Add(context);
+                }
+
+                await this.client.SendAsync(data)
+                    .ConfigureAwait(false);
+
+                bool completted = await context.WaitAsync(this.timeout, cancellationToken ?? CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                response = new Response
+                {
+                    Timeout = !completted,
+                    Status = context.Response?.Status ?? StatusCode.None,
+                    MessageCode = context.Response?.MessageCode ?? 0,
+                };
+            }
+
+            return response;
+        }
+
+        private void OnUdpMessageReceived(object sender, UdpReceiveResult e)
+        {
+            if (e == null || e.Buffer == null) return;
+
+            ResponsePacket response = null;
+            using (var ms = new MemoryStream(e.Buffer))
+            {
+                response = ResponsePacket.Read(ms);
+            }
+
+            if (response != null)
+            {
+                lock (this.pending)
+                {
+                    var context = this.pending.FirstOrDefault(x => x.IsMatch(response));
+                    if (context != null)
+                    {
+                        this.pending.Remove(context);
+
+                        context.Response = response;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/Constants.cs
+++ b/dotnet/PITreaderNetwork/Configuration/Constants.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Text;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    internal class Constants
+    {
+        public static readonly byte[] PacketMagic = Encoding.ASCII.GetBytes("PITRDMCP");
+
+        public const UInt16 PacketVersion = 1;
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/IdentifyRequest.cs
+++ b/dotnet/PITreaderNetwork/Configuration/IdentifyRequest.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.IO;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Identify Request (flash led of device)
+    /// </summary>
+    public class IdentifyRequest : RequestPacket
+    {
+        public IdentifyRequest()
+        {
+            this.Command = CommandType.Identify;
+        }
+
+        /// <summary>
+        /// Enable flashing of LED
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Timeout for fallback to default led behaviour.
+        /// </summary>
+        public UInt32 Timeout { get; set; }
+
+        /// <summary>
+        /// Write request packet to stream.
+        /// </summary>
+        /// <param name="stream">Target io stream.</param>
+        public override void Write(Stream stream)
+        {
+            base.Write(stream);
+            PacketWriter.WriteUInt8(stream, this.Enabled);
+            PacketWriter.WriteUInt32(stream, this.Timeout);
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/MulticastClient.cs
+++ b/dotnet/PITreaderNetwork/Configuration/MulticastClient.cs
@@ -1,0 +1,268 @@
+﻿/**
+ * The following code is based on https://github.com/richardschneider/net-mdns/blob/master/src/MulticastClient.cs
+ * 
+ * MIT License
+ * 
+ * Copyright (c) 2018 Richard Schneider
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    internal class MulticastClient : IDisposable
+    {
+        /// <summary>
+        ///   The port number used by the Multicast Configuration Protocol.
+        /// </summary>
+        /// <value>
+        ///   Port number 7075.
+        /// </value>
+        public static readonly int MulticastPort = 7075;
+
+        static readonly IPAddress MulticastAddressIp4 = IPAddress.Parse("239.255.0.12");
+        static readonly IPEndPoint MulticastEndpointIp4 = new IPEndPoint(MulticastAddressIp4, MulticastPort);
+
+        readonly List<UdpClient> receivers;
+        readonly ConcurrentDictionary<IPAddress, UdpClient> senders = new ConcurrentDictionary<IPAddress, UdpClient>();
+
+        public event EventHandler<UdpReceiveResult> MessageReceived;
+
+        public MulticastClient(IEnumerable<NetworkInterface> nics)
+        {
+            // Setup the receivers.
+            receivers = new List<UdpClient>();
+
+            UdpClient receiver4 = null;
+            receiver4 = new UdpClient(AddressFamily.InterNetwork);
+            receiver4.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+#if NETSTANDARD2_0
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                LinuxHelper.ReuseAddresss(receiver4.Client);
+            }
+#endif
+            receiver4.Client.Bind(new IPEndPoint(IPAddress.Any, MulticastPort));
+            receivers.Add(receiver4);
+
+            // Get the IP addresses that we should send to.
+            var addreses = nics
+                .SelectMany(GetNetworkInterfaceLocalAddresses)
+                .Where(a => a.AddressFamily == AddressFamily.InterNetwork);
+            foreach (var address in addreses)
+            {
+                if (senders.Keys.Contains(address))
+                {
+                    continue;
+                }
+
+                var localEndpoint = new IPEndPoint(address, MulticastPort);
+                var sender = new UdpClient(address.AddressFamily);
+                try
+                {
+                    switch (address.AddressFamily)
+                    {
+                        case AddressFamily.InterNetwork:
+                            receiver4.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(MulticastAddressIp4, address));
+                            sender.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+#if NETSTANDARD2_0
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                            {
+                                LinuxHelper.ReuseAddresss(sender.Client);
+                            }
+#endif
+                            sender.Client.Bind(localEndpoint);
+                            sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(MulticastAddressIp4));
+                            sender.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastLoopback, true);
+                            break;
+                        default:
+                            throw new NotSupportedException($"Address family {address.AddressFamily}.");
+                    }
+
+                    if (!senders.TryAdd(address, sender)) // Should not fail
+                    {
+                        sender.Dispose();
+                    }
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressNotAvailable)
+                {
+                    // VPN NetworkInterfaces
+                    sender.Dispose();
+                }
+                catch (Exception)
+                {
+                    sender.Dispose();
+                }
+            }
+
+            // Start listening for messages.
+            foreach (var r in receivers)
+            {
+                Listen(r);
+            }
+        }
+
+        public async Task SendAsync(byte[] message)
+        {
+            foreach (var sender in senders)
+            {
+                try
+                {
+                    await sender.Value.SendAsync(
+                        message, message.Length,
+                        MulticastEndpointIp4)
+                    .ConfigureAwait(false);
+                }
+                catch
+                {
+                    // eat it.
+                }
+            }
+        }
+
+        void Listen(UdpClient receiver)
+        {
+            // ReceiveAsync does not support cancellation.  So the receiver is disposed
+            // to stop it. See https://github.com/dotnet/corefx/issues/9848
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var task = receiver.ReceiveAsync();
+
+                    _ = task.ContinueWith(x => Listen(receiver), TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.RunContinuationsAsynchronously);
+
+                    _ = task.ContinueWith(x => MessageReceived?.Invoke(this, x.Result), TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.RunContinuationsAsynchronously);
+
+                    await task.ConfigureAwait(false);
+                }
+                catch
+                {
+                    return;
+                }
+            });
+        }
+
+        IEnumerable<IPAddress> GetNetworkInterfaceLocalAddresses(NetworkInterface nic)
+        {
+            return nic
+                .GetIPProperties()
+                .UnicastAddresses
+                .Select(x => x.Address)
+                .Where(x => x.AddressFamily != AddressFamily.InterNetworkV6 || x.IsIPv6LinkLocal)
+                ;
+        }
+
+        #region IDisposable Support
+
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    MessageReceived = null;
+
+                    foreach (var receiver in receivers)
+                    {
+                        try
+                        {
+                            receiver.Dispose();
+                        }
+                        catch
+                        {
+                            // eat it.
+                        }
+                    }
+                    receivers.Clear();
+
+                    foreach (var address in senders.Keys)
+                    {
+                        if (senders.TryRemove(address, out var sender))
+                        {
+                            try
+                            {
+                                sender.Dispose();
+                            }
+                            catch
+                            {
+                                // eat it.
+                            }
+                        }
+                    }
+                    senders.Clear();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        ~MulticastClient()
+        {
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+
+    static class LinuxHelper
+    {
+#if NETSTANDARD2_0
+        // see https://github.com/richardschneider/net-mdns/issues/22
+        public static unsafe void ReuseAddresss(Socket socket)
+        {
+            int setval = 1;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                int rv = Tmds.Linux.LibC.setsockopt(
+                    socket.Handle.ToInt32(),
+                    Tmds.Linux.LibC.SOL_SOCKET,
+                    Tmds.Linux.LibC.SO_REUSEADDR,
+                    &setval, sizeof(int));
+                if (rv != 0)
+                {
+                    throw new Exception("Socet reuse addr failed.");
+                    //todo: throw new PlatformException();
+                }
+            }
+        }
+#endif
+
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/PacketReader.cs
+++ b/dotnet/PITreaderNetwork/Configuration/PacketReader.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    internal class PacketReader
+    {
+        public static bool VerifyMagic(Stream stream)
+        {
+            byte[] input = new byte[Constants.PacketMagic.Length];
+            stream.Read(input, 0, input.Length);
+            return input.SequenceEqual(Constants.PacketMagic);
+        }
+
+        public static bool ReadBool(Stream stream)
+        {
+            return stream.ReadByte() == 1;
+        }
+
+        public static UInt16 ReadUInt16(Stream stream)
+        {
+            int value = stream.ReadByte();
+            value = value << 8 | stream.ReadByte();
+            return (UInt16)value;
+        }
+
+        public static UInt32 ReadUInt32(Stream stream)
+        {
+            UInt32 value = (UInt32)stream.ReadByte();
+            value = value << 8 | (UInt32)stream.ReadByte();
+            value = value << 8 | (UInt32)stream.ReadByte();
+            value = value << 8 | (UInt32)stream.ReadByte();
+            return value;
+        }
+
+        public static string ReadStringFixed(Stream stream, int size)
+        {
+            byte[] data = new byte[size];
+            stream.Read(data, 0, size);
+
+            int count0s = 0;
+            for (int i = size - 1; i >= 0; i--)
+            {
+                if (data[i] == 0) count0s++;
+                else break;
+            }
+
+            return Encoding.ASCII.GetString(data, 0, size - count0s);
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/PacketType.cs
+++ b/dotnet/PITreaderNetwork/Configuration/PacketType.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Packet type enumeration (request or response)
+    /// </summary>
+    public enum PacketType : UInt16
+    {
+        /// <summary>
+        /// REQUEST from a client to a device.
+        /// </summary>
+        Request = 0,
+
+        /// <summary>
+        /// RESPONSE from a device to a client.
+        /// </summary>
+        Response = 1
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/PacketWriter.cs
+++ b/dotnet/PITreaderNetwork/Configuration/PacketWriter.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    internal class PacketWriter
+    {
+        public static void WriteMagic(Stream stream)
+        {
+            stream.Write(Constants.PacketMagic, 0, Constants.PacketMagic.Length);
+        }
+
+        public static void WriteUInt8(Stream stream, bool value)
+        {
+            stream.WriteByte(value ? (byte)1 : (byte)0);
+        }
+        public static void WriteUInt8(Stream stream, byte value)
+        {
+            stream.WriteByte(value);
+        }
+
+        public static void WriteUInt16(Stream stream, UInt16 value)
+        {
+            stream.WriteByte((byte)(value >> 8));
+            stream.WriteByte((byte)value);
+        }
+
+        public static void WriteUInt32(Stream stream, UInt32 value)
+        {
+            stream.WriteByte((byte)(value >> 24));
+            stream.WriteByte((byte)(value >> 16));
+            stream.WriteByte((byte)(value >> 8));
+            stream.WriteByte((byte)value);
+        }
+
+        public static void WriteStringFixed(Stream stream, string value, uint size)
+        {
+            var result = new byte[size];
+            Array.Clear(result, 0, result.Length);
+
+            var arr = Encoding.ASCII.GetBytes(value ?? string.Empty);
+            if (arr.Length <= size)
+            {
+                arr.CopyTo(result, 0);
+            }
+            else
+            {
+                for (int i = 0; i < result.Length; i++)
+                {
+                    result[i] = arr[i];
+                }
+            }
+
+            stream.Write(result, 0, result.Length);
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/PingRequest.cs
+++ b/dotnet/PITreaderNetwork/Configuration/PingRequest.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Ping Request (check device state).
+    /// </summary>
+    public class PingRequest : RequestPacket
+    {
+        public PingRequest()
+        {
+            this.Command = CommandType.Ping;
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/RequestContext.cs
+++ b/dotnet/PITreaderNetwork/Configuration/RequestContext.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    internal class RequestContext : IDisposable
+    {
+        private readonly ManualResetEvent locking = new ManualResetEvent(false);
+
+        private ResponsePacket response;
+        private bool disposed;
+
+        public RequestContext(RequestPacket request)
+        {
+            this.Request = request ?? throw new ArgumentNullException(nameof(request));
+        }
+
+        public RequestPacket Request { get; }
+
+        public ResponsePacket Response 
+        { 
+            get => this.response;
+            set
+            {
+                if (value != null)
+                {
+                    this.response = value;
+                    if (!this.disposed) this.locking.Set();
+                }
+            }
+        }
+
+        public Task<bool> WaitAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            return this.locking.WaitOneAsync(timeout, cancellationToken);
+        }
+
+        public bool IsMatch(ResponsePacket response)
+        {
+            if (response == null || this.Request == null)
+                return false;
+
+            return this.Request.OrderNumber == response.OrderNumber
+                && this.Request.SerialNumber == response.SerialNumber
+                && (this.Request.RequestId == response.RequestId || response.RequestId == 0)
+                && (this.Request.Command == response.Command || response.Command == CommandType.None);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                if (disposing)
+                {
+                    this.locking.Dispose();
+                }
+
+                this.disposed = true;
+            }
+        }
+        
+        public void Dispose()
+        {
+            this.Dispose(true);
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/RequestPacket.cs
+++ b/dotnet/PITreaderNetwork/Configuration/RequestPacket.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.IO;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Generic Multicast Configuration Protocol request packet.
+    /// </summary>
+    public abstract class RequestPacket
+    {
+        public RequestPacket()
+        {
+            var rnd = new Random();
+            this.RequestId = (UInt32)rnd.Next();
+        }
+
+        /// <summary>
+        /// ID of the request to match response packets.
+        /// </summary>
+        public UInt32 RequestId { get; set; }
+
+        /// <summary>
+        /// Order number of the targeted device.
+        /// </summary>
+        public string OrderNumber { get; set; }
+
+        /// <summary>
+        /// Serial number of the targeted device.
+        /// </summary>
+        public string SerialNumber { get; set; }
+
+        /// <summary>
+        /// Command type of the request.
+        /// </summary>
+        public CommandType Command { get; set; }
+
+        /// <summary>
+        /// Write request packet to stream.
+        /// </summary>
+        /// <param name="stream">Target io stream.</param>
+        public virtual void Write(Stream stream)
+        {
+            PacketWriter.WriteMagic(stream);
+            PacketWriter.WriteUInt16(stream, Constants.PacketVersion);
+            PacketWriter.WriteUInt16(stream, (UInt16)PacketType.Request);
+            PacketWriter.WriteUInt32(stream, this.RequestId);
+            PacketWriter.WriteStringFixed(stream, this.OrderNumber, 12);
+            PacketWriter.WriteStringFixed(stream, this.SerialNumber, 12);
+            PacketWriter.WriteUInt32(stream, (UInt32)this.Command);
+            PacketWriter.WriteUInt16(stream, 0);
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/Response.cs
+++ b/dotnet/PITreaderNetwork/Configuration/Response.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Multicast configuration response.
+    /// </summary>
+    public class Response
+    {
+        /// <summary>
+        /// A timeout occurred (no matching response received within specified timeout).
+        /// </summary>
+        public bool Timeout { get; set; }
+
+        /// <summary>
+        /// Status of the response.
+        /// </summary>
+        public StatusCode Status { get; set; }
+
+        /// <summary>
+        /// Message code of tge response.
+        /// </summary>
+        public UInt32 MessageCode { get; set; }
+
+        /// <summary>
+        /// Success (no timeout and status: OK)
+        /// </summary>
+        public bool Success => this.Status == StatusCode.OK && !this.Timeout;
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/ResponsePacket.cs
+++ b/dotnet/PITreaderNetwork/Configuration/ResponsePacket.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.IO;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Response packet of Multicast Configuration Protocol.
+    /// </summary>
+    public class ResponsePacket
+    {
+        /// <summary>
+        /// Order number of the device.
+        /// </summary>
+        public string OrderNumber { get; set; }
+
+        /// <summary>
+        /// Serial number of the device.
+        /// </summary>
+        public string SerialNumber { get; set; }
+
+        /// <summary>
+        /// Request ID (identical to RequestId in request packet).
+        /// </summary>
+        public UInt32 RequestId { get; set; }
+
+        /// <summary>
+        /// Command type (identical to Command in request packet).
+        /// </summary>
+        public CommandType Command { get; set; }
+
+        /// <summary>
+        /// Status code.
+        /// </summary>
+        public StatusCode Status { get; set; }
+
+        /// <summary>
+        /// Message code with additional status information.
+        /// </summary>
+        public UInt32 MessageCode { get; set; }
+
+        /// <summary>
+        /// Reads response packet from stream and returns parsed packet or NULL, if no packet was present in the stream.
+        /// </summary>
+        /// <param name="stream">The io stream for reading data.</param>
+        /// <returns>The parsed response packet or NULL</returns>
+        public static ResponsePacket Read(Stream stream)
+        {
+            var response = new ResponsePacket();
+
+            if (!PacketReader.VerifyMagic(stream)) return null;
+
+            // Version
+            if (PacketReader.ReadUInt16(stream) != Constants.PacketVersion) return null;
+            if (PacketReader.ReadUInt16(stream) != (UInt16)PacketType.Response) return null;
+
+            response.RequestId = PacketReader.ReadUInt32(stream);
+
+            response.OrderNumber = PacketReader.ReadStringFixed(stream, 12);
+            response.SerialNumber = PacketReader.ReadStringFixed(stream, 12);
+
+            response.Command = (CommandType)PacketReader.ReadUInt32(stream);
+
+            // Extension
+            if (PacketReader.ReadUInt16(stream) != 0) return null;
+
+            response.Status = (StatusCode)PacketReader.ReadUInt16(stream);
+            response.MessageCode = PacketReader.ReadUInt32(stream);
+            return response;
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/SetIPv4Request.cs
+++ b/dotnet/PITreaderNetwork/Configuration/SetIPv4Request.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System.IO;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// SetIPv4 Request (configure network settings of device).
+    /// </summary>
+    public class SetIPv4Request : RequestPacket
+    {
+        public SetIPv4Request()
+        {
+            this.Command = CommandType.SetIPv4;
+        }
+
+        /// <summary>
+        /// IP address of the device.
+        /// </summary>
+        public string DeviceIp { get; set; }
+
+        /// <summary>
+        /// Subnetmask to identify local network.
+        /// </summary>
+        public string Netmask { get; set; }
+
+        /// <summary>
+        /// IP address of standard gateway.
+        /// </summary>
+        public string GatewayIp { get; set; }
+
+        /// <summary>
+        /// Write request packet to stream.
+        /// </summary>
+        /// <param name="stream">Target io stream.</param>
+        public override void Write(Stream stream)
+        {
+            base.Write(stream);
+            this.WriteIpString(stream, this.DeviceIp);
+            this.WriteIpString(stream, this.Netmask);
+            this.WriteIpString(stream, this.GatewayIp);
+        }
+
+        private void WriteIpString(Stream stream, string ip)
+        {
+            string[] parts = (ip ?? string.Empty).Split('.');
+
+            for (int i = 0; i < 4; i++)
+            {
+                byte value;
+                if (parts.Length <= i || !byte.TryParse(parts[i], out value)) value = 0;
+                PacketWriter.WriteUInt8(stream, value);
+            }
+
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/StatusCode.cs
+++ b/dotnet/PITreaderNetwork/Configuration/StatusCode.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    /// <summary>
+    /// Status code returned by device.
+    /// </summary>
+    public enum StatusCode
+    {
+        /// <summary>
+        /// Default undefined value.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Request successfully processed.
+        /// </summary>
+        OK = 200,
+
+        /// <summary>
+        /// Invalid data provided in request.
+        /// </summary>
+        InvalidData = 400,
+
+        /// <summary>
+        /// Authentication required to perform request (i.e. no default password set in device).
+        /// </summary>
+        AuthRequired = 401,
+
+        /// <summary>
+        /// Invalid authentication.
+        /// </summary>
+        Forbidden = 403,
+
+        /// <summary>
+        /// Command type of request is not known to the device.
+        /// </summary>
+        UnknownCommand = 404,
+
+        /// <summary>
+        /// An internal error occurred processing the request.
+        /// </summary>
+        InternalError = 500,
+    }
+}

--- a/dotnet/PITreaderNetwork/Configuration/TaskExtensions.cs
+++ b/dotnet/PITreaderNetwork/Configuration/TaskExtensions.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pilz.PITreader.Network.Configuration
+{
+    internal static class TaskExtensions
+    {
+        public static async Task<bool> WaitOneAsync(this WaitHandle handle, int millisecondsTimeout, CancellationToken cancellationToken)
+        {
+            RegisteredWaitHandle registeredHandle = null;
+            CancellationTokenRegistration tokenRegistration = default(CancellationTokenRegistration);
+            try
+            {
+                var tcs = new TaskCompletionSource<bool>();
+
+                registeredHandle = ThreadPool.RegisterWaitForSingleObject(
+                    handle,
+                    (state, timedOut) => ((TaskCompletionSource<bool>)state).TrySetResult(!timedOut),
+                    tcs,
+                    millisecondsTimeout,
+                    true);
+
+                tokenRegistration = cancellationToken.Register(
+                    state => ((TaskCompletionSource<bool>)state).TrySetCanceled(),
+                    tcs);
+
+                return await tcs.Task;
+            }
+            finally
+            {
+                if (registeredHandle != null)
+                    registeredHandle.Unregister(null);
+                
+                tokenRegistration.Dispose();
+            }
+        }
+
+        public static Task<bool> WaitOneAsync(this WaitHandle handle, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            return handle.WaitOneAsync((int)timeout.TotalMilliseconds, cancellationToken);
+        }
+
+        public static Task<bool> WaitOneAsync(this WaitHandle handle, CancellationToken cancellationToken)
+        {
+            return handle.WaitOneAsync(Timeout.Infinite, cancellationToken);
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/NetworkInterfaceEventArgs.cs
+++ b/dotnet/PITreaderNetwork/NetworkInterfaceEventArgs.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+
+namespace Pilz.PITreader.Network
+{
+    /// <summary>
+    /// The event data for <see cref="PITreaderNetworkScan.NetworkInterfaceDiscovered"/>.
+    /// </summary>
+    public class NetworkInterfaceEventArgs : EventArgs
+    {
+        public NetworkInterfaceEventArgs(IEnumerable<NetworkInterface> networkInterfaces)
+        {
+            this.NetworkInterfaces = networkInterfaces ?? throw new ArgumentNullException(nameof(networkInterfaces));
+        }
+
+        /// <summary>
+        ///   The sequece of detected network interfaces.
+        /// </summary>
+        /// <value>
+        ///   A sequence of network interfaces.
+        /// </value>
+        public IEnumerable<NetworkInterface> NetworkInterfaces { get; set; }
+    }
+}

--- a/dotnet/PITreaderNetwork/PITreaderNetwork.csproj
+++ b/dotnet/PITreaderNetwork/PITreaderNetwork.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Pilz.PITreader.Network</RootNamespace>
+    <AssemblyName>Pilz.PITreader.Network</AssemblyName>
+	<Company>Pilz GmbH &amp; Co. KG</Company>
+	<Authors>Pilz GmbH &amp; Co. KG</Authors>
+	<Copyright>© 2023 Pilz GmbH &amp; Co. KG</Copyright>
+	<Description>Client library to perform network scans and configuration for Pilz PITreader devices.</Description>
+	<Product>PITreader Network Scan and Configuration</Product>
+	<Version>1.0.0</Version>
+	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	<RepositoryUrl>https://github.com/PilzDE/pitreader.git</RepositoryUrl>
+	<PackageProjectUrl>https://github.com/PilzDE/PITreader</PackageProjectUrl>
+	<PackageTags>PITreader Pilz mdns network-scan</PackageTags>
+	<PackageIcon></PackageIcon>
+	<RepositoryType>git</RepositoryType>
+	<PackageReleaseNotes>Initial version for PITreader FW 2.0</PackageReleaseNotes>
+	<PackageId>Pilz.PITreader.Network</PackageId>
+	<SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Makaretu.Dns.Multicast" Version="0.27.0" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/PITreaderNetwork/PITreaderNetworkScan.cs
+++ b/dotnet/PITreaderNetwork/PITreaderNetworkScan.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Threading;
+using Makaretu.Dns;
+
+namespace Pilz.PITreader.Network
+{
+    /// <summary>
+    /// Handler to perform network scan for PITreader devices.
+    /// </summary>
+    public class PITreaderNetworkScan
+    {
+        private const string DeviceServiceName = "pitreader.pilz.local";
+
+        private readonly MulticastService mdns;
+
+        private Timer timer;
+
+        /// <summary>
+        /// Creates a new network scan instance.
+        /// </summary>
+        /// <param name="networkInterfaceFilter">Filter for correct network interface.</param>
+        public PITreaderNetworkScan(Func<IEnumerable<NetworkInterface>, IEnumerable<NetworkInterface>> networkInterfaceFilter)
+        {
+            this.mdns = new MulticastService(networkInterfaceFilter)
+            {
+                UseIpv4 = true,
+                UseIpv6 = false
+            };
+
+            this.mdns.NetworkInterfaceDiscovered += this.OnNetworkInterfaceDiscovered;
+            this.mdns.AnswerReceived += this.OnMdnsAnswerReceived;
+
+            this.timer = null;
+        }
+
+        /// <summary>
+        /// Event is triggered when a PITreader device is discovered.
+        /// Filtering for duplicate devices needs to be done by the caller.
+        /// </summary>
+        public EventHandler<PITreaderScanResultEventArgs> DeviceDiscovered;
+
+        /// <summary>
+        /// Event is triggered when a network interface is discovered.
+        /// Filtering for duplicate interfaces needs to be done by the caller.
+        /// </summary>
+        public EventHandler<NetworkInterfaceEventArgs> NetworkInterfaceDiscovered;
+
+        /// <summary>
+        /// Start scanning for devices on the selected network.
+        /// The interval is 15 seconds.
+        /// </summary>
+        public void Start()
+        {
+            this.mdns.Start();
+
+            if (this.timer == null)
+            {
+                this.timer = new Timer((object o) => this.Query(), null, 15000, 15000);
+            }
+        }
+
+        /// <summary>
+        /// Stops the mdns service
+        /// </summary>
+        public void Stop()
+        {
+            // Stop removes all event listeners
+            this.mdns.Stop();
+
+            if (this.timer != null)
+            {
+                this.timer.Dispose();
+                this.timer = null;
+            }
+        }
+
+        /// <summary>
+        /// Restart scanning for devices (i.e. when the selected network interface changed).
+        /// </summary>
+        public void Restart()
+        {
+            // Stop removes all event listeners
+            this.mdns.Stop();
+
+            this.mdns.NetworkInterfaceDiscovered += this.OnNetworkInterfaceDiscovered;
+            this.mdns.AnswerReceived += this.OnMdnsAnswerReceived;
+            this.mdns.Start();
+
+            this.Query();
+        }
+
+        /// <summary>
+        /// Send a query to detect devices on the selected network.
+        /// </summary>
+        public void Query()
+        {
+            this.mdns.SendQuery(DeviceServiceName, DnsClass.IN, DnsType.ANY);
+        }
+
+        private void OnMdnsAnswerReceived(object sender, MessageEventArgs e)
+        {
+            if (e == null)
+                return;
+
+            if (!e.Message.Answers.Any(q => string.Equals(q.CanonicalName, DeviceServiceName, StringComparison.InvariantCultureIgnoreCase)))
+                return;
+
+            if (this.DeviceDiscovered == null)
+                return;
+
+            var model = new PITreaderScanResult
+            {
+                IpAddress = e.RemoteEndPoint.Address.ToString(),
+                HttpsPort = 443
+            };
+
+            var srv = e.Message.AdditionalRecords.OfType<SRVRecord>().FirstOrDefault();
+            if (srv != null && srv.Name == "_https._tcp.local") model.HttpsPort = srv.Port;
+
+            foreach (var ar in e.Message.AdditionalRecords.OfType<TXTRecord>())
+            {
+                foreach (var str in ar.Strings)
+                {
+                    var parts = str.Split(new char[] { '=' }, 2);
+                    if (parts.Length == 2)
+                    {
+                        switch (parts[0])
+                        {
+                            case "on": model.OrderNumber = parts[1]; break;
+                            case "sn": model.SerialNumber = parts[1]; break;
+                            case "mac": model.MacAddress = parts[1]; break;
+                        }
+                    }
+                }
+            }
+
+            this.DeviceDiscovered(this, new PITreaderScanResultEventArgs(model));
+        }
+
+        private void OnNetworkInterfaceDiscovered(object sender, Makaretu.Dns.NetworkInterfaceEventArgs e)
+        {
+            if (e == null)
+                return;
+
+            if (this.NetworkInterfaceDiscovered != null)
+            {
+                var interfaceList = e.NetworkInterfaces.Where(item => item.OperationalStatus == OperationalStatus.Up
+                    && item.SupportsMulticast).ToList();
+
+                this.NetworkInterfaceDiscovered(this, new NetworkInterfaceEventArgs(interfaceList));
+            }
+
+            this.Query();
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/PITreaderScanResult.cs
+++ b/dotnet/PITreaderNetwork/PITreaderScanResult.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+
+namespace Pilz.PITreader.Network
+{
+    /// <summary>
+    /// Model to represent a PITreader device.
+    /// </summary>
+    public class PITreaderScanResult : IEquatable<PITreaderScanResult>
+    {
+        private string ipAddress;
+        private ushort httpsPort;
+        private string orderNumber;
+        private string serialNumber;
+        private string macAddress;
+
+        /// <summary>
+        /// IP address of the device.
+        /// </summary>
+        public string IpAddress 
+        { 
+            get => this.ipAddress;
+            set 
+            {
+                if (this.ipAddress != value)
+                {
+                    this.ipAddress = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// HTTPS port number configured in the device (default: 443)
+        /// </summary>
+        public ushort HttpsPort 
+        { 
+            get => this.httpsPort;
+            set
+            {
+                if (this.httpsPort != value)
+                {
+                    this.httpsPort = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Order number of the device.
+        /// </summary>
+        public string OrderNumber 
+        { 
+            get => this.orderNumber;
+            set
+            {
+                if (this.orderNumber != value)
+                {
+                    this.orderNumber = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Serial number of the device.
+        /// </summary>
+        public string SerialNumber 
+        { 
+            get => this.serialNumber;
+            set
+            {
+                if (this.serialNumber != value)
+                {
+                    this.serialNumber = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// MAC address of the device.
+        /// </summary>
+        public string MacAddress 
+        { 
+            get => this.macAddress;
+            set
+            {
+                if (this.macAddress != value)
+                {
+                    this.macAddress = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Updates data of object with data from other object
+        /// </summary>
+        /// <param name="other">Other PITreader device</param>
+        public void Update(PITreaderScanResult other)
+        {
+            if (other is null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            this.IpAddress = other.IpAddress;
+            this.HttpsPort = other.HttpsPort;
+            this.OrderNumber = other.OrderNumber;
+            this.SerialNumber = other.SerialNumber;
+            this.MacAddress = other.MacAddress;
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// The comparison is based on order and serial number.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>true if the current object is equal to the other parameter; otherwise, false.</returns>
+        public bool Equals(PITreaderScanResult other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return string.Equals(this.OrderNumber, other.OrderNumber, StringComparison.InvariantCultureIgnoreCase)
+                && string.Equals(this.SerialNumber, other.SerialNumber, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/dotnet/PITreaderNetwork/PITreaderScanResultEventArgs.cs
+++ b/dotnet/PITreaderNetwork/PITreaderScanResultEventArgs.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) 2023 Pilz GmbH & Co. KG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
+
+using System;
+
+namespace Pilz.PITreader.Network
+{
+    /// <summary>
+    /// The event data for <see cref="PITreaderNetworkScan.DeviceDiscovered"/>.
+    /// </summary>
+    public class PITreaderScanResultEventArgs : EventArgs
+    {
+        public PITreaderScanResultEventArgs(PITreaderScanResult device)
+        {
+            this.Device = device ?? throw new ArgumentNullException(nameof(device));
+        }
+
+        /// <summary>
+        /// The discovered PITreader device.
+        /// </summary>
+        public PITreaderScanResult Device { get; }
+    }
+}

--- a/dotnet/PITreaderNetwork/Pilz.PITreader.Network.csproj
+++ b/dotnet/PITreaderNetwork/Pilz.PITreader.Network.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Makaretu.Dns.Multicast" Version="0.27.0" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/Sandbox/Program.cs
+++ b/dotnet/Sandbox/Program.cs
@@ -1,0 +1,13 @@
+﻿using Pilz.PITreader.Client;
+
+var client = new PITreaderClient("192.168.0.16", 443, certificateValidation: CertificateValidators.AcceptAll);
+client.ApiToken = "YRqk2wYciMiX4lj2GNWL0Q=="; //  "RYWNW1r51N9Q47em6cBHjg==";
+
+var update = new PITreaderFirmwareManager(client);
+var fileName = @"C:\Users\%USERNAME%\Downloads\PITreader_update_2-1-0.zip";
+
+var package = new PITreaderFirmwarePackage(fileName);
+await update.PerformUpdateAsync(package, true);
+
+Console.WriteLine("Done");
+Console.ReadLine();

--- a/dotnet/Sandbox/Sandbox.csproj
+++ b/dotnet/Sandbox/Sandbox.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PITreaderClient\PITreaderClient.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This adds a commissioning client to the library.

Core driver for this feature is to provide the ability to setup a PITreader device with a single command line call.

E.g.

```batch
PITreaderCommissioningTool.exe run ^
	--scan-timeout=10 ^
	--set-ip=192.168.0.16 --set-netmask=255.255.255.0 --set-gateway=0.0.0.0 ^
	--config=PITreader_default.config ^
	--config-strip-network ^
	--commissioning-user=factory ^
	--coding=coding.txt ^
	--coding-oem=coding_oem.txt ^
	--firmware=PITreader_update_2-1-0.fwu ^
	--regenerate-certificate ^
	--opc-ua-server-certiftcate-destination=opua-server-cert.der
```

Missing features:

- [ ] Usage example and documentation
- [ ] Network scan strategies for multiple devices
- [x] Automatic password generation
- [ ] Complete high-level model for configuration files
